### PR TITLE
chore: rename crate groundwork → socle

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to groundwork
+# Contributing to socle
 
 Thank you for your interest in contributing!
 
@@ -12,8 +12,8 @@ Thank you for your interest in contributing!
 ## Development setup
 
 ```bash
-git clone https://github.com/brefwiz/groundwork
-cd groundwork
+git clone https://github.com/brefwiz/socle
+cd socle
 cp .env.example .env   # if present, otherwise set DATABASE_URL manually
 cargo build
 ```
@@ -25,7 +25,7 @@ cargo build
 cargo test
 
 # All tests including integration (requires DATABASE_URL)
-DATABASE_URL=postgres://localhost/groundwork_test cargo test
+DATABASE_URL=postgres://localhost/socle_test cargo test
 
 # Coverage
 cargo llvm-cov --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "groundwork"
+name = "socle"
 version = "0.1.0"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 description = "Opinionated axum service bootstrap: telemetry, database, rate limiting, and shutdown in one builder"
 license = "MIT"
-repository = "https://github.com/brefwiz/groundwork"
+repository = "https://github.com/brefwiz/socle"
 readme = "README.md"
 keywords = ["axum", "tower", "bootstrap", "http", "telemetry"]
 categories = ["web-programming::http-server", "asynchronous"]

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# groundwork
+# socle
 
-[![CI](https://github.com/brefwiz/groundwork/actions/workflows/ci.yml/badge.svg)](https://github.com/brefwiz/groundwork/actions/workflows/ci.yml)
-[![crates.io](https://img.shields.io/crates/v/groundwork.svg)](https://crates.io/crates/groundwork)
-[![docs.rs](https://docs.rs/groundwork/badge.svg)](https://docs.rs/groundwork)
+[![CI](https://github.com/brefwiz/socle/actions/workflows/ci.yml/badge.svg)](https://github.com/brefwiz/socle/actions/workflows/ci.yml)
+[![crates.io](https://img.shields.io/crates/v/socle.svg)](https://crates.io/crates/socle)
+[![docs.rs](https://docs.rs/socle/badge.svg)](https://docs.rs/socle)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Rust 1.85+](https://img.shields.io/badge/rust-1.85%2B-orange.svg)](https://www.rust-lang.org)
 
@@ -10,7 +10,7 @@ Every new service in a platform starts the same way. Someone wires up `tracing-s
 
 This is the problem that gets worse in the AI era. An agent scaffolding a new service will invent its own `main.rs` from scratch — different shutdown ordering, different observability setup, different error handling — unless there is a single bootstrap to reach for.
 
-**groundwork is that bootstrap.** One builder, one call to `serve()`, and your service gets: structured tracing, Postgres connection + migrations, in-process GCRA rate limiting, request-ID propagation, health endpoints, graceful shutdown with drain hooks, CORS, body-size limiting, panic recovery, and OpenAPI + Swagger UI — all wired in the correct order, consistently, every time.
+**socle is that bootstrap.** One builder, one call to `serve()`, and your service gets: structured tracing, Postgres connection + migrations, in-process GCRA rate limiting, request-ID propagation, health endpoints, graceful shutdown with drain hooks, CORS, body-size limiting, panic recovery, and OpenAPI + Swagger UI — all wired in the correct order, consistently, every time.
 
 ## Who this is for
 
@@ -23,11 +23,11 @@ This is the problem that gets worse in the AI era. An agent scaffolding a new se
 
 ```toml
 [dependencies]
-groundwork = "0.1"
+socle = "0.1"
 ```
 
 ```rust
-use groundwork::{ServiceBootstrap, BootstrapCtx, Result};
+use socle::{ServiceBootstrap, BootstrapCtx, Result};
 use axum::{Router, routing::get};
 
 #[tokio::main]
@@ -52,12 +52,12 @@ See [`examples/`](examples/) for runnable examples.
 Load all settings from environment variables or a TOML file, then pass the config to the builder. Useful for 12-factor services and Kubernetes deployments.
 
 ```rust
-use groundwork::{ServiceBootstrap, BootstrapConfig, Result};
+use socle::{ServiceBootstrap, BootstrapConfig, Result};
 use axum::{Router, routing::get};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // Reads GROUNDWORK_* env vars, DATABASE_URL, OTEL_EXPORTER_OTLP_ENDPOINT
+    // Reads SOCLE_* env vars, DATABASE_URL, OTEL_EXPORTER_OTLP_ENDPOINT
     let cfg = BootstrapConfig::from_env()?;
     ServiceBootstrap::from_config("payments-service", cfg)?
         .with_router(|_| Router::new().route("/ping", get(|| async { "pong" })))
@@ -100,7 +100,7 @@ GET /health/ready
 Register dependency checks with `with_readiness_check`:
 
 ```rust
-use groundwork::ServiceBootstrap;
+use socle::ServiceBootstrap;
 use api_bones::health::HealthCheck;
 
 ServiceBootstrap::new("billing-service")
@@ -115,7 +115,7 @@ ServiceBootstrap::new("billing-service")
 Add GCRA rate limiting in one line. The limiter is backed by `governor` and applied as a tower layer — no middleware to wire manually.
 
 ```rust
-use groundwork::{ServiceBootstrap, RateLimitBackend, RateLimitExtractor};
+use socle::{ServiceBootstrap, RateLimitBackend, RateLimitExtractor};
 
 ServiceBootstrap::new("api-gateway")
     .with_rate_limit(RateLimitBackend { limit: 100, window_secs: 60 })
@@ -146,7 +146,7 @@ Register async callbacks that run after the HTTP server stops accepting connecti
 
 ```rust
 use std::time::Duration;
-use groundwork::ServiceBootstrap;
+use socle::ServiceBootstrap;
 
 ServiceBootstrap::new("worker-service")
     .with_shutdown_hook("flush-metrics", Duration::from_secs(5), || async {
@@ -162,7 +162,7 @@ ServiceBootstrap::new("worker-service")
 No CORS headers are sent unless you configure them explicitly. There is no "allow all origins" default.
 
 ```rust
-use groundwork::{ServiceBootstrap, CorsConfig};
+use socle::{ServiceBootstrap, CorsConfig};
 
 ServiceBootstrap::new("public-api")
     .with_cors_config(CorsConfig {
@@ -178,7 +178,7 @@ ServiceBootstrap::new("public-api")
 Mount a utoipa-generated spec and Swagger UI with a single call. The health endpoints are merged into the spec automatically.
 
 ```rust
-use groundwork::ServiceBootstrap;
+use socle::ServiceBootstrap;
 use utoipa::OpenApi;
 
 #[derive(OpenApi)]
@@ -193,10 +193,10 @@ ServiceBootstrap::new("orders-service")
 
 ### Escape hatches for wrapper crates
 
-Inject arbitrary tower layers and access the fully-constructed context in the router builder. This is how `service-kit` and other internal wrapper crates extend groundwork without forking `serve()`.
+Inject arbitrary tower layers and access the fully-constructed context in the router builder. This is how `service-kit` and other internal wrapper crates extend socle without forking `serve()`.
 
 ```rust
-use groundwork::{ServiceBootstrap, BootstrapCtx};
+use socle::{ServiceBootstrap, BootstrapCtx};
 use axum::Router;
 
 ServiceBootstrap::new("platform-service")
@@ -276,7 +276,7 @@ ServiceBootstrap::new("platform-service")
 
 | Method | Description |
 |--------|-------------|
-| `BootstrapConfig::from_env()` | Load from `GROUNDWORK_*` env vars |
+| `BootstrapConfig::from_env()` | Load from `SOCLE_*` env vars |
 | `BootstrapConfig::load(path)` | Load from TOML file with env-var overrides |
 | `BootstrapConfig::validate()` | Validate cross-field invariants |
 
@@ -284,12 +284,12 @@ Environment variables honored automatically:
 
 | Env var | Field |
 |---------|-------|
-| `GROUNDWORK_BIND_ADDR` | `bind_addr` |
-| `GROUNDWORK_HEALTH_PATH` | `health_path` |
-| `GROUNDWORK_LOG_LEVEL` | `log_level` |
-| `GROUNDWORK_LOG_FORMAT` | `log_format` (`pretty` or `json`) |
-| `GROUNDWORK_SHUTDOWN_TIMEOUT_SECS` | `shutdown_timeout_secs` |
-| `GROUNDWORK_BODY_LIMIT_BYTES` | `body_limit_bytes` |
+| `SOCLE_BIND_ADDR` | `bind_addr` |
+| `SOCLE_HEALTH_PATH` | `health_path` |
+| `SOCLE_LOG_LEVEL` | `log_level` |
+| `SOCLE_LOG_FORMAT` | `log_format` (`pretty` or `json`) |
+| `SOCLE_SHUTDOWN_TIMEOUT_SECS` | `shutdown_timeout_secs` |
+| `SOCLE_BODY_LIMIT_BYTES` | `body_limit_bytes` |
 | `DATABASE_URL` | `database_url` |
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | `otel_endpoint` |
 
@@ -327,6 +327,20 @@ Layers are applied in this order, outermost first (i.e. request processing goes 
 | `validation` | — | `Valid<T>` extractor via `validator` |
 | `cursor` | — | HMAC-signed opaque pagination cursors |
 | `testing` | — | `reqwest`-based test helpers |
+
+## Prior art
+
+**[`loco`](https://loco.rs)** is the closest crate in spirit — a batteries-included, Rails-inspired framework with an ORM, mailers, background jobs, CLI generation, and built-in auth. If you want a full-stack analogue to Rails, use loco. socle is a library, not a framework: it imposes no project structure, no ORM, no CLI, and no conventions beyond the bootstrap call itself. You bring axum routes; socle brings consistent plumbing.
+
+**[`shuttle`](https://www.shuttle.rs)** solves a different problem: managed cloud deployment via an annotated `#[shuttle_runtime::main]`. It owns your infrastructure. socle owns nothing outside `serve()` and works with any deployment target.
+
+**Roll-your-own boilerplate** is the real competitor — most teams copy a `main.rs` from the previous service and diverge over time. Four services in, telemetry is initialised four different ways, health endpoints are missing on two of them, and graceful shutdown drains in the wrong order on one. socle is what that shared boilerplate would look like if it were tested, versioned, and depended on rather than copied.
+
+Three things socle does that the alternatives don't:
+
+- **Correct layer ordering, always.** Rate-limiting wraps auth wraps the user router wraps telemetry — in that order, enforced by the builder, not documented somewhere and hoped for.
+- **Per-hook shutdown timeouts with drain ordering.** Hooks run in reverse registration order; each has its own deadline. Getting this right in every service individually is the kind of thing that fails silently in production.
+- **Port traits for wrapper crates.** `AuthProvider` and `RateLimitProvider` let internal platforms extend socle without forking `serve()`. Add your JWT layer, your distributed rate limiter, your org-context middleware — socle stays upgradeable.
 
 ## MSRV
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -8,7 +8,7 @@ Only the latest published version on crates.io receives security fixes.
 
 Please **do not** open a public issue for security vulnerabilities.
 
-Open a [private security advisory](https://github.com/brefwiz/groundwork/security/advisories/new) on GitHub, or email the maintainers at **security@brefwiz.com**.
+Open a [private security advisory](https://github.com/brefwiz/socle/security/advisories/new) on GitHub, or email the maintainers at **security@brefwiz.com**.
 
 Include:
 

--- a/deny.toml
+++ b/deny.toml
@@ -6,7 +6,7 @@ db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 ignore = [
     # rsa Marvin timing side-channel (RUSTSEC-2023-0071) surfaces via
-    # sqlx-mysql which is a transitive dep of sqlx. groundwork only enables
+    # sqlx-mysql which is a transitive dep of sqlx. socle only enables
     # the postgres feature so the mysql (and rsa) code paths are never compiled
     # or linked. No actionable fix until sqlx drops the mysql dep or patches rsa.
     "RUSTSEC-2023-0071",

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,7 +1,7 @@
 //! Minimal service: telemetry + one route.
 
 use axum::{Router, routing::get};
-use groundwork::{BootstrapCtx, Result, ServiceBootstrap};
+use socle::{BootstrapCtx, Result, ServiceBootstrap};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/examples/with_database.rs
+++ b/examples/with_database.rs
@@ -3,7 +3,7 @@
 //! Requires `DATABASE_URL` in the environment (or a `.env` file).
 
 use axum::{Router, extract::State, routing::get};
-use groundwork::{BootstrapCtx, Result, ServiceBootstrap};
+use socle::{BootstrapCtx, Result, ServiceBootstrap};
 use sqlx::PgPool;
 
 async fn health(State(pool): State<PgPool>) -> &'static str {

--- a/examples/with_ratelimit.rs
+++ b/examples/with_ratelimit.rs
@@ -3,7 +3,7 @@
 //! Limits each IP to 100 requests per 60-second window.
 
 use axum::{Router, routing::get};
-use groundwork::{BootstrapCtx, RateLimitBackend, RateLimitExtractor, Result, ServiceBootstrap};
+use socle::{BootstrapCtx, RateLimitBackend, RateLimitExtractor, Result, ServiceBootstrap};
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/src/bootstrap/builder.rs
+++ b/src/bootstrap/builder.rs
@@ -40,7 +40,7 @@ pub(crate) struct ShutdownHook {
 /// Builder for a microservice runtime.
 ///
 /// ```rust,no_run
-/// use groundwork::{ServiceBootstrap, BootstrapCtx, Result};
+/// use socle::{ServiceBootstrap, BootstrapCtx, Result};
 /// use axum::{Router, routing::get};
 ///
 /// # #[tokio::main] async fn main() -> Result<()> {
@@ -313,7 +313,7 @@ impl ServiceBootstrap {
     /// wrapper crate:
     ///
     /// ```rust,no_run
-    /// use groundwork::{ServiceBootstrap, ports::telemetry::TelemetryProvider, Result};
+    /// use socle::{ServiceBootstrap, ports::telemetry::TelemetryProvider, Result};
     ///
     /// struct MyOtelProvider;
     /// impl TelemetryProvider for MyOtelProvider {
@@ -402,7 +402,7 @@ impl ServiceBootstrap {
     ///
     /// ```rust,no_run
     /// use axum::Router;
-    /// use groundwork::{ServiceBootstrap, ports::rate_limit::RateLimitProvider};
+    /// use socle::{ServiceBootstrap, ports::rate_limit::RateLimitProvider};
     ///
     /// struct MyDistributedRl;
     /// impl RateLimitProvider for MyDistributedRl {
@@ -437,7 +437,7 @@ impl ServiceBootstrap {
     ///
     /// ```rust,no_run
     /// use axum::Router;
-    /// use groundwork::{ServiceBootstrap, ports::auth::AuthProvider};
+    /// use socle::{ServiceBootstrap, ports::auth::AuthProvider};
     ///
     /// struct MyJwtAuth;
     /// impl AuthProvider for MyJwtAuth {

--- a/src/bootstrap/ctx.rs
+++ b/src/bootstrap/ctx.rs
@@ -9,7 +9,7 @@ use std::sync::Arc;
 /// In addition to the typed fields, an arbitrary type map is available via
 /// [`BootstrapCtx::insert`] / [`BootstrapCtx::get`]. Service-kit and other
 /// Brefwiz layers use this to inject internal resources (e.g. a
-/// `ConnectionSource`) without requiring groundwork to know about them.
+/// `ConnectionSource`) without requiring socle to know about them.
 #[derive(Clone)]
 pub struct BootstrapCtx {
     pub(crate) service_name: Arc<str>,
@@ -37,7 +37,7 @@ impl BootstrapCtx {
 
     /// Store an arbitrary value in the extension map.
     ///
-    /// Used by wrapper crates (e.g. service-kit) to inject types that groundwork
+    /// Used by wrapper crates (e.g. service-kit) to inject types that socle
     /// doesn't know about. Overwrites any previously stored value of the same type.
     pub fn insert<T: Send + Sync + 'static>(&mut self, val: T) {
         self.extensions.insert(TypeId::of::<T>(), Arc::new(val));

--- a/src/bootstrap/serve.rs
+++ b/src/bootstrap/serve.rs
@@ -21,7 +21,7 @@ impl ServiceBootstrap {
         let listener = tokio::net::TcpListener::bind(addr)
             .await
             .map_err(|e| Error::Bind(e.to_string()))?;
-        tracing::info!(%addr, service = %self.service_name, "groundwork: listening");
+        tracing::info!(%addr, service = %self.service_name, "socle: listening");
         self.serve_with_shutdown(listener, shutdown_signal()).await
     }
 
@@ -31,7 +31,7 @@ impl ServiceBootstrap {
     ///
     /// ```rust,no_run
     /// use axum::{Router, routing::get};
-    /// use groundwork::{BootstrapCtx, Result, ServiceBootstrap};
+    /// use socle::{BootstrapCtx, Result, ServiceBootstrap};
     /// use tokio::net::TcpListener;
     ///
     /// # #[tokio::main] async fn main() -> Result<()> {
@@ -125,13 +125,13 @@ impl ServiceBootstrap {
             if let Some(ref migrator) = migrator {
                 tracing::warn!(
                     service = %service_name,
-                    "groundwork: running migrations in-process"
+                    "socle: running migrations in-process"
                 );
                 migrator
                     .run(&pool)
                     .await
                     .map_err(|e| Error::Database(format!("migrate: {e}")))?;
-                tracing::info!("groundwork: migrations applied successfully");
+                tracing::info!("socle: migrations applied successfully");
             }
             Some(pool)
         } else if let Some(ref url) = database_url {
@@ -142,13 +142,13 @@ impl ServiceBootstrap {
             if let Some(ref migrator) = migrator {
                 tracing::warn!(
                     service = %service_name,
-                    "groundwork: running migrations in-process"
+                    "socle: running migrations in-process"
                 );
                 migrator
                     .run(&pool)
                     .await
                     .map_err(|e| Error::Database(format!("migrate: {e}")))?;
-                tracing::info!("groundwork: migrations applied successfully");
+                tracing::info!("socle: migrations applied successfully");
             }
 
             Some(pool)
@@ -275,20 +275,20 @@ impl ServiceBootstrap {
         server.await.map_err(|e| Error::Serve(e.to_string()))?;
 
         run_shutdown_hooks(shutdown_hooks, shutdown_timeout).await;
-        tracing::info!(service = %service_name, "groundwork: shutdown complete");
+        tracing::info!(service = %service_name, "socle: shutdown complete");
         Ok(())
     }
 }
 
 async fn run_shutdown_hooks(hooks: Vec<ShutdownHook>, _default_timeout: std::time::Duration) {
     for hook in hooks.into_iter().rev() {
-        tracing::info!(hook = %hook.name, "groundwork: running shutdown hook");
+        tracing::info!(hook = %hook.name, "socle: running shutdown hook");
         match tokio::time::timeout(hook.timeout, (hook.hook)()).await {
-            Ok(()) => tracing::info!(hook = %hook.name, "groundwork: shutdown hook completed"),
+            Ok(()) => tracing::info!(hook = %hook.name, "socle: shutdown hook completed"),
             Err(_) => tracing::error!(
                 hook = %hook.name,
                 timeout_secs = hook.timeout.as_secs(),
-                "groundwork: shutdown hook timed out"
+                "socle: shutdown hook timed out"
             ),
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -154,7 +154,7 @@ impl BootstrapConfig {
         if let Some(p) = path {
             fig = fig.merge(Toml::file(p));
         }
-        fig.merge(Env::prefixed("GROUNDWORK_").split("__"))
+        fig.merge(Env::prefixed("SOCLE_").split("__"))
             .merge(
                 Env::raw()
                     .only(&["DATABASE_URL"])
@@ -212,12 +212,12 @@ mod tests {
     }
 
     #[test]
-    fn from_env_reads_groundwork_prefixed_vars() {
+    fn from_env_reads_socle_prefixed_vars() {
         let _g = ENV_LOCK.lock().unwrap();
         // SAFETY: ENV_LOCK serialises all env-var mutations in this module.
-        unsafe { std::env::set_var("GROUNDWORK_BIND_ADDR", "127.0.0.1:9999") };
+        unsafe { std::env::set_var("SOCLE_BIND_ADDR", "127.0.0.1:9999") };
         let cfg = BootstrapConfig::from_env().unwrap();
-        unsafe { std::env::remove_var("GROUNDWORK_BIND_ADDR") };
+        unsafe { std::env::remove_var("SOCLE_BIND_ADDR") };
         assert_eq!(cfg.bind_addr, "127.0.0.1:9999");
     }
 
@@ -258,9 +258,9 @@ mod tests {
         let mut f = tempfile::NamedTempFile::new().unwrap();
         writeln!(f, r#"bind_addr = "0.0.0.0:1234""#).unwrap();
         // SAFETY: ENV_LOCK serialises all env-var mutations in this module.
-        unsafe { std::env::set_var("GROUNDWORK_BIND_ADDR", "0.0.0.0:5678") };
+        unsafe { std::env::set_var("SOCLE_BIND_ADDR", "0.0.0.0:5678") };
         let cfg = BootstrapConfig::load(f.path()).unwrap();
-        unsafe { std::env::remove_var("GROUNDWORK_BIND_ADDR") };
+        unsafe { std::env::remove_var("SOCLE_BIND_ADDR") };
         assert_eq!(cfg.bind_addr, "0.0.0.0:5678");
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,8 @@
-//! Error type for `groundwork`.
+//! Error type for `socle`.
 
 use thiserror::Error;
 
-/// Result alias used throughout `groundwork`.
+/// Result alias used throughout `socle`.
 pub type Result<T> = std::result::Result<T, Error>;
 
 /// Errors that can occur while bootstrapping or running a service.

--- a/src/extract.rs
+++ b/src/extract.rs
@@ -1,4 +1,4 @@
-//! Axum extractors provided by groundwork.
+//! Axum extractors provided by socle.
 
 #[cfg(feature = "validation")]
 pub use validation::Valid;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,11 +1,11 @@
-//! # groundwork
+//! # socle
 //!
 //! Opinionated axum service bootstrap: telemetry, database, rate limiting, and
 //! shutdown in one builder. Public open-source facade extracted from an internal
 //! service kit.
 //!
 //! ```rust,no_run
-//! use groundwork::{ServiceBootstrap, BootstrapCtx, Result};
+//! use socle::{ServiceBootstrap, BootstrapCtx, Result};
 //! use axum::{Router, routing::get};
 //!
 //! # #[tokio::main] async fn main() -> Result<()> {
@@ -93,7 +93,7 @@ pub use api_bones::{Slug, SlugError};
 /// #[openapi()]
 /// struct ApiDoc;
 ///
-/// groundwork::generate_openapi_binary!(ApiDoc);
+/// socle::generate_openapi_binary!(ApiDoc);
 /// # }
 /// ```
 #[cfg(feature = "openapi")]
@@ -121,7 +121,7 @@ macro_rules! generate_openapi_binary {
 /// OpenAPI helpers for callers generating specs outside of [`ServiceBootstrap::serve`].
 #[cfg(feature = "openapi")]
 pub mod openapi {
-    /// Merge groundwork's built-in health path definitions into `api`.
+    /// Merge socle's built-in health path definitions into `api`.
     pub fn merge_health_paths(
         api: utoipa::openapi::OpenApi,
         health_path: &str,

--- a/src/ports/auth.rs
+++ b/src/ports/auth.rs
@@ -1,6 +1,6 @@
 //! Auth port — extension point for pluggable authentication middleware.
 //!
-//! Unlike rate-limit, groundwork ships **no** built-in auth backend. The
+//! Unlike rate-limit, socle ships **no** built-in auth backend. The
 //! authentication landscape is too varied (JWT/JWKS, OIDC, OAuth2, API keys,
 //! mTLS, custom headers) and a default would either be useless or dangerous.
 //!
@@ -10,7 +10,7 @@
 //!
 //! ```rust,no_run
 //! use axum::Router;
-//! use groundwork::ports::auth::AuthProvider;
+//! use socle::ports::auth::AuthProvider;
 //!
 //! struct JwtAuthProvider { /* JWKS cache, issuer, audience, api-key store */ }
 //!

--- a/src/ports/rate_limit.rs
+++ b/src/ports/rate_limit.rs
@@ -8,7 +8,7 @@
 //!
 //! ```rust,no_run
 //! use axum::Router;
-//! use groundwork::ports::rate_limit::RateLimitProvider;
+//! use socle::ports::rate_limit::RateLimitProvider;
 //!
 //! struct DistributedRateLimit { /* distributed-ratelimit config */ }
 //!

--- a/src/ports/telemetry.rs
+++ b/src/ports/telemetry.rs
@@ -13,13 +13,13 @@ use std::pin::Pin;
 
 /// Extension point for telemetry initialisation.
 ///
-/// Wrapper crates supply a concrete implementation; groundwork calls `init` at
+/// Wrapper crates supply a concrete implementation; socle calls `init` at
 /// the start of `serve()` and registers `on_shutdown` as a drain hook after the
 /// HTTP server stops.
 ///
 /// ```rust,no_run
-/// use groundwork::ports::telemetry::TelemetryProvider;
-/// use groundwork::Result;
+/// use socle::ports::telemetry::TelemetryProvider;
+/// use socle::Result;
 ///
 /// struct MyOtelProvider;
 ///

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -1,4 +1,4 @@
-//! Test helpers shared across services built on groundwork.
+//! Test helpers shared across services built on socle.
 //!
 //! Enabled by the `testing` feature.
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2,7 +2,7 @@
 //! random port, hit it with `reqwest`, assert responses.
 
 use axum::{Router, routing::get};
-use groundwork::{BootstrapCtx, ServiceBootstrap, testing::TestClient};
+use socle::{BootstrapCtx, ServiceBootstrap, testing::TestClient};
 use tokio::sync::oneshot;
 
 // ── helpers ───────────────────────────────────────────────────────────────────
@@ -91,7 +91,7 @@ async fn unknown_route_returns_404_problem_json() {
 #[cfg(feature = "ratelimit-memory")]
 #[tokio::test]
 async fn rate_limit_blocks_after_limit_exceeded() {
-    use groundwork::RateLimitBackend;
+    use socle::RateLimitBackend;
 
     let (client, _stop) = spawn_service(|s| {
         s.with_rate_limit(RateLimitBackend {


### PR DESCRIPTION
## Summary

- Renames the crate from `groundwork` to `socle` throughout — `Cargo.toml`, all source files, tests, examples, and docs
- Updates the env config prefix `GROUNDWORK_` → `SOCLE_` and the `repository` URL to `github.com/brefwiz/socle`
- Renames log strings (`"groundwork: listening"` → `"socle: listening"`) in `serve.rs`

**Why:** `groundwork` was already taken on crates.io. `socle` (architectural base of a column) is axum-agnostic and was available.

## Test plan

- [x] `make clippy` clean on default + `--no-default-features`
- [x] service-kit compiles against the renamed crate via path dep

🤖 Generated with [Claude Code](https://claude.com/claude-code)