### PR TITLE
fix(ci): use crates=socle in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ jobs:
   release:
     uses: brefwiz/shared-ci-workflows/.github/workflows/release-rust.yml@main
     with:
-      crates: "groundwork"
+      crates: "socle"
     secrets:
       cargo-registry-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
     permissions:


### PR DESCRIPTION
## Summary

- Fixes the release pipeline that failed after the groundwork → socle rename
- `crates: "groundwork"` → `crates: "socle"` in `.github/workflows/release.yml`

Closes the error: `package ID specification \`groundwork\` did not match any packages`

## Test plan

- [x] Merge and tag `v*` to verify the publish workflow runs against the correct crate name

🤖 Generated with [Claude Code](https://claude.com/claude-code)