### PR TITLE
feat(handler): HandlerResponse + HandlerListResponse; remove HandlerResult

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+## [1.0.0] — 2026-04-21
+
+### Added
+
+- `HandlerResponse<T>` — envelope-aware return type for single-resource handlers: `Result<(StatusCode, Json<ApiResponse<T>>), HandlerError>`.
+- `HandlerListResponse<T>` — envelope-aware return type for collection handlers: `Result<Json<ApiResponse<PaginatedResponse<T>>>, HandlerError>`.
+
+### Removed
+
+- `HandlerResult<T>` — bare `Json<T>` wrapper removed. Migrate to `HandlerResponse<T>` or `HandlerListResponse<T>`.
+
 ## [0.1.2] — 2026-04-21
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "socle"
-version = "0.1.2"
+version = "1.0.0"
 dependencies = [
  "api-bones",
  "axum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "socle"
-version = "0.1.2"
+version = "1.0.0"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 description = "Opinionated axum service bootstrap: telemetry, database, rate limiting, and shutdown in one builder"

--- a/src/handler_error.rs
+++ b/src/handler_error.rs
@@ -63,8 +63,18 @@ impl IntoResponse for HandlerError {
     }
 }
 
-/// Convenience return type for handlers that return a JSON body on success.
-pub type HandlerResult<T> = Result<axum::Json<T>, HandlerError>;
+/// Return type for handlers that return a single resource wrapped in the platform envelope.
+pub type HandlerResponse<T> = Result<
+    (
+        axum::http::StatusCode,
+        axum::Json<api_bones::ApiResponse<T>>,
+    ),
+    HandlerError,
+>;
+
+/// Return type for handlers that return a paginated collection wrapped in the platform envelope.
+pub type HandlerListResponse<T> =
+    Result<axum::Json<api_bones::ApiResponse<api_bones::PaginatedResponse<T>>>, HandlerError>;
 
 /// Convenience return type for handlers that return `201 Created` with a JSON body.
 pub type CreatedResult<T> = Result<(axum::http::StatusCode, axum::Json<T>), HandlerError>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,8 @@ pub use config::{BootstrapConfig, CorsConfig, LogFormat, RateLimitConfig, RateLi
 pub use error::{Error, Result};
 pub use etag::{ETag, IfMatch, IfNoneMatch, check_if_match, etag_from_updated_at};
 pub use handler_error::{
-    ApiError, CreatedResult, ErrorCode, HandlerError, HandlerResult, ProblemJson, ValidationError,
+    ApiError, CreatedResult, ErrorCode, HandlerError, HandlerListResponse, HandlerResponse,
+    ProblemJson, ValidationError,
 };
 pub use pagination::{
     CursorPaginatedResponse, CursorPagination, CursorPaginationParams, KeysetPaginatedResponse,


### PR DESCRIPTION
## Summary

- Removes \`HandlerResult<T>\` (bare \`Json<T>\` wrapper, violated ADR platform/0016 envelope contract)
- Adds \`HandlerResponse<T>\` = \`Result<(StatusCode, Json<ApiResponse<T>>), HandlerError>\`
- Adds \`HandlerListResponse<T>\` = \`Result<Json<ApiResponse<PaginatedResponse<T>>>, HandlerError>\`

## Test plan

- [x] \`cargo test --lib\` — 103 tests pass
- [x] New types compile and re-export correctly from \`socle::\` root

🤖 Generated with [Claude Code](https://claude.com/claude-code)