### PR TITLE
feat: add listed(), ok(), created() envelope helpers to handler_error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## [Unreleased]
 
+## [1.1.0] — 2026-04-23
+
+### Added
+
+- `created<T>(value)` — builds `(StatusCode::CREATED, Json(ApiResponse::builder(value).build()))` for `CreatedResponse` handlers.
+- `ok<T>(value)` — builds `(StatusCode::OK, Json(ApiResponse::builder(value).build()))` for `HandlerResponse` handlers.
+- `listed<T>(page)` — builds `Json(ApiResponse::builder(page).build())` for `HandlerListResponse` handlers.
+- `CreatedResponse<T>` — return type alias for handlers that create a resource and return it with a 201 status.
+- `EtaggedHandlerResponse<T>` — return type alias for handlers that carry an ETag response header alongside the platform envelope.
+
+### Removed
+
+- `CreatedResult<T>` — pre-envelope bare `Json<T>` alias. Migrate to `CreatedResponse<T>` + `created()`.
+
 ## [1.0.0] — 2026-04-21
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -583,7 +583,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1989,7 +1989,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2047,7 +2047,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2058,9 +2058,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -2304,7 +2304,7 @@ dependencies = [
 
 [[package]]
 name = "socle"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "api-bones",
  "axum",
@@ -2616,7 +2616,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "socle"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 description = "Opinionated axum service bootstrap: telemetry, database, rate limiting, and shutdown in one builder"

--- a/src/handler_error.rs
+++ b/src/handler_error.rs
@@ -76,8 +76,57 @@ pub type HandlerResponse<T> = Result<
 pub type HandlerListResponse<T> =
     Result<axum::Json<api_bones::ApiResponse<api_bones::PaginatedResponse<T>>>, HandlerError>;
 
-/// Convenience return type for handlers that return `201 Created` with a JSON body.
-pub type CreatedResult<T> = Result<(axum::http::StatusCode, axum::Json<T>), HandlerError>;
+/// Return type for handlers that create a resource and return it with a 201 status.
+pub type CreatedResponse<T> = Result<
+    (
+        axum::http::StatusCode,
+        axum::Json<api_bones::ApiResponse<T>>,
+    ),
+    HandlerError,
+>;
+
+/// Return type for read/update handlers that carry an ETag response header.
+pub type EtaggedHandlerResponse<T> = Result<
+    (
+        api_bones::etag::ETag,
+        axum::http::StatusCode,
+        axum::Json<api_bones::ApiResponse<T>>,
+    ),
+    HandlerError,
+>;
+
+/// Build the success value for a [`CreatedResponse`] handler (201 Created).
+pub fn created<T>(
+    value: T,
+) -> (
+    axum::http::StatusCode,
+    axum::Json<api_bones::ApiResponse<T>>,
+) {
+    (
+        axum::http::StatusCode::CREATED,
+        axum::Json(api_bones::ApiResponse::builder(value).build()),
+    )
+}
+
+/// Build the success value for a [`HandlerResponse`] handler (200 OK).
+pub fn ok<T>(
+    value: T,
+) -> (
+    axum::http::StatusCode,
+    axum::Json<api_bones::ApiResponse<T>>,
+) {
+    (
+        axum::http::StatusCode::OK,
+        axum::Json(api_bones::ApiResponse::builder(value).build()),
+    )
+}
+
+/// Build the success value for a [`HandlerListResponse`] handler.
+pub fn listed<T>(
+    page: api_bones::PaginatedResponse<T>,
+) -> axum::Json<api_bones::ApiResponse<api_bones::PaginatedResponse<T>>> {
+    axum::Json(api_bones::ApiResponse::builder(page).build())
+}
 
 /// Build a Problem+JSON 500 response from a panic payload. Used in catch-panic layer.
 pub(crate) fn panic_handler(err: Box<dyn std::any::Any + Send + 'static>) -> Response {
@@ -144,5 +193,31 @@ mod tests {
         let payload: Box<dyn std::any::Any + Send + 'static> = Box::new(42u32);
         let resp = panic_handler(payload);
         assert_eq!(resp.status(), 500);
+    }
+
+    #[test]
+    fn created_builds_201_with_envelope() {
+        let (status, body) = created("x");
+        assert_eq!(status, axum::http::StatusCode::CREATED);
+        let json = serde_json::to_value(body.0).unwrap();
+        assert_eq!(json["data"], "x");
+    }
+
+    #[test]
+    fn ok_builds_200_with_envelope() {
+        let (status, body) = ok(42u32);
+        assert_eq!(status, axum::http::StatusCode::OK);
+        let json = serde_json::to_value(body.0).unwrap();
+        assert_eq!(json["data"], 42);
+    }
+
+    #[test]
+    fn listed_wraps_paginated_response() {
+        use api_bones::{PaginatedResponse, pagination::PaginationParams};
+        let page: PaginatedResponse<u32> =
+            PaginatedResponse::new(vec![1, 2], 2, &PaginationParams::default());
+        let body = listed(page);
+        let json = serde_json::to_value(body.0).unwrap();
+        assert_eq!(json["data"]["items"], serde_json::json!([1, 2]));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,8 +45,8 @@ pub use config::{BootstrapConfig, CorsConfig, LogFormat, RateLimitConfig, RateLi
 pub use error::{Error, Result};
 pub use etag::{ETag, IfMatch, IfNoneMatch, check_if_match, etag_from_updated_at};
 pub use handler_error::{
-    ApiError, CreatedResult, ErrorCode, HandlerError, HandlerListResponse, HandlerResponse,
-    ProblemJson, ValidationError,
+    ApiError, CreatedResponse, ErrorCode, EtaggedHandlerResponse, HandlerError,
+    HandlerListResponse, HandlerResponse, ProblemJson, ValidationError, created, listed, ok,
 };
 pub use pagination::{
     CursorPaginatedResponse, CursorPagination, CursorPaginationParams, KeysetPaginatedResponse,


### PR DESCRIPTION
## Summary

- Adds `created()`, `ok()`, and `listed()` helper functions to `socle::handler_error` so axum handlers can build `ApiResponse<T>` envelopes without spelling out `Json(ApiResponse::builder(v).build())` at every call site
- Adds `CreatedResponse<T>` and `EtaggedHandlerResponse<T>` type aliases alongside the existing `HandlerResponse<T>` / `HandlerListResponse<T>`
- Removes legacy `CreatedResult<T>` (pre-envelope bare-`Json` alias, unused outside socle itself)
- Bumps to `1.1.0`

These helpers belong in `socle` rather than `service-kit` because socle already has every dependency needed (`axum`, `api_bones`), and `service-kit` builds on top of `socle`. `service-kit` will re-export them once this lands.

## Test plan

- [x] `cargo test --lib` — 106/106 tests pass including 3 new ones (`created_builds_201_with_envelope`, `ok_builds_200_with_envelope`, `listed_wraps_paginated_response`)
- [x] `cargo clippy --all-targets --no-deps -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)