### PR TITLE
feat(http-client): trace-propagating reqwest client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -93,6 +93,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -583,7 +594,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -827,6 +838,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "governor"
@@ -1440,7 +1457,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1500,6 +1517,39 @@ name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "opentelemetry"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab70038c28ed37b97d8ed414b6429d343a8bbf44c9f79ec854f3a643029ba6d7"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 1.0.69",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "231e9d6ceef9b0b2546ddf52335785ce41252bc7474ee8ba05bfad277be13ab8"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "glob",
+ "opentelemetry",
+ "percent-encoding",
+ "rand 0.8.6",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tracing",
+]
 
 [[package]]
 name = "parking"
@@ -1906,6 +1956,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "reqwest-middleware"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "199dda04a536b532d0cc04d7979e39b1c763ea749bf91507017069c00b96056f"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "http",
+ "reqwest",
+ "thiserror 2.0.18",
+ "tower-service",
+]
+
+[[package]]
 name = "ring"
 version = "0.17.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1989,7 +2053,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2047,7 +2111,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2299,7 +2363,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2307,6 +2371,7 @@ name = "socle"
 version = "1.1.0"
 dependencies = [
  "api-bones",
+ "async-trait",
  "axum",
  "bytes",
  "chrono",
@@ -2314,8 +2379,12 @@ dependencies = [
  "figment",
  "futures-util",
  "governor",
+ "http",
  "http-body-util",
+ "opentelemetry",
+ "opentelemetry_sdk",
  "reqwest",
+ "reqwest-middleware",
  "serde",
  "serde_json",
  "sqlx",
@@ -2616,7 +2685,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3311,7 +3380,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ validation = ["dep:validator"]
 cursor = ["api-bones/base64"]
 
 testing = ["dep:reqwest"]
+http-client = ["dep:reqwest", "dep:reqwest-middleware", "dep:opentelemetry", "dep:async-trait", "dep:http"]
 
 [dependencies]
 axum = { version = "0.8", features = ["macros"] }
@@ -64,6 +65,10 @@ utoipa-swagger-ui = { version = "9", default-features = false, features = ["axum
 dotenvy = { version = "0.15", optional = true }
 
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"], optional = true }
+reqwest-middleware = { version = "0.5", optional = true }
+opentelemetry = { version = "0.27", optional = true }
+async-trait = { version = "0.1", optional = true }
+http = { version = "1", optional = true }
 
 validator = { version = "0.20", features = ["derive"], optional = true }
 
@@ -75,6 +80,7 @@ http-body-util = "0.1"
 bytes = "1"
 tempfile = "3"
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "postgres"] }
+opentelemetry_sdk = { version = "0.27", features = ["trace"] }
 
 [[example]]
 name = "minimal"

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -1,22 +1,12 @@
-use std::collections::HashMap;
-
 use async_trait::async_trait;
 use opentelemetry::{Context, global, propagation::Injector};
-use reqwest::header::{HeaderName, HeaderValue};
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
 use reqwest_middleware::{
     ClientBuilder as MiddlewareClientBuilder, ClientWithMiddleware, Middleware, Next,
     Result as MiddlewareResult,
 };
 
 use crate::request_id::CURRENT_REQUEST_ID;
-
-struct HashMapInjector<'a>(&'a mut HashMap<String, String>);
-
-impl Injector for HashMapInjector<'_> {
-    fn set(&mut self, key: &str, value: String) {
-        self.0.insert(key.to_owned(), value);
-    }
-}
 
 struct TraceContextMiddleware;
 
@@ -29,19 +19,21 @@ impl Middleware for TraceContextMiddleware {
         next: Next<'_>,
     ) -> MiddlewareResult<reqwest::Response> {
         let cx = Context::current();
-        let mut carrier: HashMap<String, String> = HashMap::new();
         global::get_text_map_propagator(|propagator| {
-            propagator.inject_context(&cx, &mut HashMapInjector(&mut carrier));
+            let mut injector = HeaderMapInjector(req.headers_mut());
+            propagator.inject_context(&cx, &mut injector);
         });
-        for (key, value) in carrier {
-            if let (Ok(name), Ok(val)) = (
-                HeaderName::from_bytes(key.as_bytes()),
-                HeaderValue::from_str(&value),
-            ) {
-                req.headers_mut().insert(name, val);
-            }
-        }
         next.run(req, extensions).await
+    }
+}
+
+struct HeaderMapInjector<'a>(&'a mut HeaderMap);
+
+impl Injector for HeaderMapInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        if let (Ok(name), Ok(val)) = (HeaderName::try_from(key), HeaderValue::try_from(value)) {
+            self.0.insert(name, val);
+        }
     }
 }
 
@@ -55,13 +47,16 @@ impl Middleware for RequestIdMiddleware {
         extensions: &mut http::Extensions,
         next: Next<'_>,
     ) -> MiddlewareResult<reqwest::Response> {
-        if let Ok(id) = CURRENT_REQUEST_ID.try_with(|id| id.clone()) {
-            if !id.is_empty() {
-                if let Ok(val) = HeaderValue::from_str(&id) {
-                    req.headers_mut().insert("x-request-id", val);
+        CURRENT_REQUEST_ID
+            .try_with(|id| {
+                if let (Ok(name), Ok(val)) = (
+                    HeaderName::try_from("x-request-id"),
+                    HeaderValue::from_str(id.as_str()),
+                ) {
+                    req.headers_mut().entry(name).or_insert(val);
                 }
-            }
-        }
+            })
+            .ok();
         next.run(req, extensions).await
     }
 }
@@ -74,8 +69,15 @@ pub fn builder() -> ClientBuilder {
 }
 
 /// Thin wrapper around [`reqwest::ClientBuilder`].
+#[must_use = "ClientBuilder does nothing until you call .build()"]
 pub struct ClientBuilder {
     inner: reqwest::ClientBuilder,
+}
+
+impl Default for ClientBuilder {
+    fn default() -> Self {
+        builder()
+    }
 }
 
 impl ClientBuilder {
@@ -89,8 +91,8 @@ impl ClientBuilder {
         self
     }
 
-    pub fn user_agent(mut self, value: impl AsRef<str>) -> Self {
-        self.inner = self.inner.user_agent(value.as_ref());
+    pub fn user_agent(mut self, value: impl Into<String>) -> Self {
+        self.inner = self.inner.user_agent(value.into());
         self
     }
 

--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -1,0 +1,272 @@
+use std::collections::HashMap;
+
+use async_trait::async_trait;
+use opentelemetry::{Context, global, propagation::Injector};
+use reqwest::header::{HeaderName, HeaderValue};
+use reqwest_middleware::{
+    ClientBuilder as MiddlewareClientBuilder, ClientWithMiddleware, Middleware, Next,
+    Result as MiddlewareResult,
+};
+
+use crate::request_id::CURRENT_REQUEST_ID;
+
+struct HashMapInjector<'a>(&'a mut HashMap<String, String>);
+
+impl Injector for HashMapInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        self.0.insert(key.to_owned(), value);
+    }
+}
+
+struct TraceContextMiddleware;
+
+#[async_trait]
+impl Middleware for TraceContextMiddleware {
+    async fn handle(
+        &self,
+        mut req: reqwest::Request,
+        extensions: &mut http::Extensions,
+        next: Next<'_>,
+    ) -> MiddlewareResult<reqwest::Response> {
+        let cx = Context::current();
+        let mut carrier: HashMap<String, String> = HashMap::new();
+        global::get_text_map_propagator(|propagator| {
+            propagator.inject_context(&cx, &mut HashMapInjector(&mut carrier));
+        });
+        for (key, value) in carrier {
+            if let (Ok(name), Ok(val)) = (
+                HeaderName::from_bytes(key.as_bytes()),
+                HeaderValue::from_str(&value),
+            ) {
+                req.headers_mut().insert(name, val);
+            }
+        }
+        next.run(req, extensions).await
+    }
+}
+
+struct RequestIdMiddleware;
+
+#[async_trait]
+impl Middleware for RequestIdMiddleware {
+    async fn handle(
+        &self,
+        mut req: reqwest::Request,
+        extensions: &mut http::Extensions,
+        next: Next<'_>,
+    ) -> MiddlewareResult<reqwest::Response> {
+        if let Ok(id) = CURRENT_REQUEST_ID.try_with(|id| id.clone()) {
+            if !id.is_empty() {
+                if let Ok(val) = HeaderValue::from_str(&id) {
+                    req.headers_mut().insert("x-request-id", val);
+                }
+            }
+        }
+        next.run(req, extensions).await
+    }
+}
+
+/// Entry point: returns a [`ClientBuilder`] with sensible defaults.
+pub fn builder() -> ClientBuilder {
+    ClientBuilder {
+        inner: reqwest::ClientBuilder::new(),
+    }
+}
+
+/// Thin wrapper around [`reqwest::ClientBuilder`].
+pub struct ClientBuilder {
+    inner: reqwest::ClientBuilder,
+}
+
+impl ClientBuilder {
+    pub fn timeout(mut self, duration: std::time::Duration) -> Self {
+        self.inner = self.inner.timeout(duration);
+        self
+    }
+
+    pub fn connect_timeout(mut self, duration: std::time::Duration) -> Self {
+        self.inner = self.inner.connect_timeout(duration);
+        self
+    }
+
+    pub fn user_agent(mut self, value: impl AsRef<str>) -> Self {
+        self.inner = self.inner.user_agent(value.as_ref());
+        self
+    }
+
+    pub fn default_headers(mut self, headers: reqwest::header::HeaderMap) -> Self {
+        self.inner = self.inner.default_headers(headers);
+        self
+    }
+
+    pub fn from_reqwest_builder(builder: reqwest::ClientBuilder) -> Self {
+        ClientBuilder { inner: builder }
+    }
+
+    pub fn build(self) -> Result<Client, reqwest::Error> {
+        let reqwest_client = self.inner.build()?;
+        let client = MiddlewareClientBuilder::new(reqwest_client)
+            .with(TraceContextMiddleware)
+            .with(RequestIdMiddleware)
+            .build();
+        Ok(Client { inner: client })
+    }
+}
+
+/// Cloneable wrapper around [`reqwest_middleware::ClientWithMiddleware`].
+#[derive(Clone)]
+pub struct Client {
+    inner: ClientWithMiddleware,
+}
+
+impl Client {
+    pub fn get(&self, url: impl reqwest::IntoUrl) -> reqwest_middleware::RequestBuilder {
+        self.inner.get(url)
+    }
+
+    pub fn post(&self, url: impl reqwest::IntoUrl) -> reqwest_middleware::RequestBuilder {
+        self.inner.post(url)
+    }
+
+    pub fn put(&self, url: impl reqwest::IntoUrl) -> reqwest_middleware::RequestBuilder {
+        self.inner.put(url)
+    }
+
+    pub fn patch(&self, url: impl reqwest::IntoUrl) -> reqwest_middleware::RequestBuilder {
+        self.inner.patch(url)
+    }
+
+    pub fn delete(&self, url: impl reqwest::IntoUrl) -> reqwest_middleware::RequestBuilder {
+        self.inner.delete(url)
+    }
+
+    pub fn head(&self, url: impl reqwest::IntoUrl) -> reqwest_middleware::RequestBuilder {
+        self.inner.head(url)
+    }
+
+    pub fn request(
+        &self,
+        method: reqwest::Method,
+        url: impl reqwest::IntoUrl,
+    ) -> reqwest_middleware::RequestBuilder {
+        self.inner.request(method, url)
+    }
+
+    pub fn inner(&self) -> &ClientWithMiddleware {
+        &self.inner
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{Router, extract::Request as AxumRequest, routing::get};
+    use std::sync::{Arc, Mutex};
+    use tokio::net::TcpListener;
+
+    async fn capture_headers(
+        axum::extract::State(captured): axum::extract::State<Arc<Mutex<Vec<(String, String)>>>>,
+        req: AxumRequest,
+    ) -> &'static str {
+        let mut guard = captured.lock().unwrap();
+        for (k, v) in req.headers() {
+            if let Ok(v) = v.to_str() {
+                guard.push((k.to_string(), v.to_string()));
+            }
+        }
+        "ok"
+    }
+
+    async fn start_server(captured: Arc<Mutex<Vec<(String, String)>>>) -> String {
+        let app = Router::new()
+            .route("/", get(capture_headers))
+            .with_state(captured);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+        format!("http://{addr}")
+    }
+
+    #[tokio::test]
+    async fn builder_builds_successfully() {
+        let client = builder().build();
+        assert!(client.is_ok());
+    }
+
+    #[tokio::test]
+    async fn from_reqwest_builder_preserves_configuration() {
+        let rb = reqwest::ClientBuilder::new();
+        let client = ClientBuilder::from_reqwest_builder(rb).build();
+        assert!(client.is_ok());
+    }
+
+    #[tokio::test]
+    async fn no_traceparent_without_propagator() {
+        let captured: Arc<Mutex<Vec<(String, String)>>> = Arc::new(Mutex::new(vec![]));
+        let url = start_server(captured.clone()).await;
+        let client = builder().build().unwrap();
+        client.get(&url).send().await.unwrap();
+        let headers = captured.lock().unwrap();
+        assert!(!headers.iter().any(|(k, _)| k == "traceparent"));
+    }
+
+    #[tokio::test]
+    async fn traceparent_injected_with_propagator() {
+        use opentelemetry::trace::{TraceContextExt as _, Tracer as _, TracerProvider as _};
+        use opentelemetry_sdk::propagation::TraceContextPropagator;
+        use opentelemetry_sdk::trace::TracerProvider;
+
+        let provider = TracerProvider::builder().build();
+        let tracer = provider.tracer("test");
+        opentelemetry::global::set_text_map_propagator(TraceContextPropagator::new());
+
+        let captured: Arc<Mutex<Vec<(String, String)>>> = Arc::new(Mutex::new(vec![]));
+        let url = start_server(captured.clone()).await;
+        let client = builder().build().unwrap();
+
+        let span = tracer.start("test-span");
+        let cx = opentelemetry::Context::current_with_span(span);
+        let _guard = cx.attach();
+
+        client.get(&url).send().await.unwrap();
+
+        let headers = captured.lock().unwrap();
+        assert!(
+            headers.iter().any(|(k, _)| k == "traceparent"),
+            "expected traceparent header, got: {headers:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn request_id_forwarded_when_set() {
+        let captured: Arc<Mutex<Vec<(String, String)>>> = Arc::new(Mutex::new(vec![]));
+        let url = start_server(captured.clone()).await;
+        let client = builder().build().unwrap();
+
+        CURRENT_REQUEST_ID
+            .scope("test-req-id".to_owned(), async {
+                client.get(&url).send().await.unwrap();
+            })
+            .await;
+
+        let headers = captured.lock().unwrap();
+        assert!(
+            headers
+                .iter()
+                .any(|(k, v)| k == "x-request-id" && v == "test-req-id"),
+            "expected x-request-id: test-req-id, got: {headers:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_request_id_when_not_set() {
+        let captured: Arc<Mutex<Vec<(String, String)>>> = Arc::new(Mutex::new(vec![]));
+        let url = start_server(captured.clone()).await;
+        let client = builder().build().unwrap();
+        client.get(&url).send().await.unwrap();
+        let headers = captured.lock().unwrap();
+        assert!(!headers.iter().any(|(k, _)| k == "x-request-id"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,9 @@ pub mod pagination;
 #[cfg(feature = "testing")]
 pub mod testing;
 
+#[cfg(feature = "http-client")]
+pub mod http_client;
+
 // ── Public surface ────────────────────────────────────────────────────────────
 
 pub use bootstrap::{BootstrapCtx, ServiceBootstrap, ShutdownHookFn};


### PR DESCRIPTION
## Summary

- Adds `http-client` Cargo feature (off by default)
- Exposes `socle::http_client::builder()` returning a `Client` backed by `reqwest-middleware`
- `TraceContextMiddleware` injects W3C `traceparent`/`tracestate` via global OTel propagator; no-op when none installed
- `RequestIdMiddleware` forwards `CURRENT_REQUEST_ID` task-local as `x-request-id`; no-op when not set
- 5 unit tests cover: build success, from_reqwest_builder, no traceparent without propagator, traceparent injected with propagator, x-request-id forwarding

Closes #14

## Test plan

- [x] `cargo check --features http-client` — clean
- [x] `cargo clippy --features http-client -- -D warnings` — clean
- [x] `cargo test --features http-client` — 102 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)