### PR TITLE
feat(testing): promote TestApp ephemeral-server harness

### DIFF
--- a/src/testing/app.rs
+++ b/src/testing/app.rs
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: LicenseRef-Proprietary
+//! [`TestApp`] — spawn a real Axum server on an ephemeral port.
+
+use std::net::SocketAddr;
+
+use axum::Router;
+use tokio::net::TcpListener;
+use tokio::sync::oneshot;
+use tokio::task::JoinHandle;
+
+use super::TestClient;
+
+/// A running test server.  Drop or call [`TestApp::shutdown`] when done.
+pub struct TestApp {
+    /// The address the server is listening on.
+    pub addr: SocketAddr,
+    shutdown_tx: Option<oneshot::Sender<()>>,
+    handle: Option<JoinHandle<()>>,
+}
+
+impl TestApp {
+    /// Create a [`TestAppBuilder`].
+    pub fn builder() -> TestAppBuilder {
+        TestAppBuilder::default()
+    }
+
+    /// Return a [`TestClient`] pre-configured with this server's base URL.
+    pub fn client(&self) -> TestClient {
+        TestClient::new(format!("http://{}", self.addr))
+    }
+
+    /// Send the shutdown signal and wait for the server task to finish.
+    pub async fn shutdown(mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(handle) = self.handle.take() {
+            let _ = handle.await;
+        }
+    }
+}
+
+impl Drop for TestApp {
+    fn drop(&mut self) {
+        if let Some(tx) = self.shutdown_tx.take() {
+            let _ = tx.send(());
+        }
+        if let Some(handle) = self.handle.take() {
+            handle.abort();
+        }
+    }
+}
+
+/// Builder for [`TestApp`].
+#[derive(Default)]
+pub struct TestAppBuilder {
+    router: Option<Router>,
+}
+
+impl TestAppBuilder {
+    /// Set the Axum router the test server will serve.
+    pub fn router(mut self, router: Router) -> Self {
+        self.router = Some(router);
+        self
+    }
+
+    /// Bind to an ephemeral port and start the server.
+    pub async fn build(self) -> TestApp {
+        let listener = TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("failed to bind ephemeral port");
+        let addr = listener.local_addr().expect("no local addr");
+
+        let router = self.router.unwrap_or_default();
+        let (tx, rx) = oneshot::channel::<()>();
+
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, router)
+                .with_graceful_shutdown(async {
+                    let _ = rx.await;
+                })
+                .await
+                .expect("test server failed");
+        });
+
+        TestApp {
+            addr,
+            shutdown_tx: Some(tx),
+            handle: Some(handle),
+        }
+    }
+}

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -6,6 +6,12 @@
 pub use test_client::TestClient;
 
 #[cfg(feature = "testing")]
+pub mod app;
+
+#[cfg(feature = "testing")]
+pub use app::{TestApp, TestAppBuilder};
+
+#[cfg(feature = "testing")]
 pub mod trace;
 
 #[cfg(feature = "testing")]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -135,3 +135,18 @@ async fn capture_exporter_drain_empties_buffer() {
     assert!(drained.iter().any(|s| s.name == "drain_op"));
     assert!(exporter.spans().is_empty());
 }
+
+#[tokio::test]
+async fn test_app_builder_serves_and_shuts_down() {
+    use axum::http::StatusCode;
+    use socle::testing::{TestApp, TestClient};
+
+    let router = Router::new().route("/ping", get(|| async { StatusCode::OK }));
+    let app = TestApp::builder().router(router).build().await;
+
+    let client: TestClient = app.client();
+    let resp = client.get("/ping").await;
+    assert_eq!(resp.status(), 200);
+
+    app.shutdown().await;
+}


### PR DESCRIPTION
## Summary

- Add `TestApp` and `TestAppBuilder` to `socle::testing` (ported from `service-kit`, stripped of `testing-pg`/database fields)
- `TestApp::builder().router(r).build().await` binds to `127.0.0.1:0` and spawns a gracefully-shutdownable Axum server
- `TestApp::client()` returns a `TestClient` pre-pointed at the bound address; `Drop` aborts the task without panic

Closes #17

## Test plan

- `cargo test --features testing test_app_builder_serves_and_shuts_down` — builds minimal router, issues GET, asserts 200, shuts down cleanly
- `cargo clippy --features testing -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)