### PR TITLE
docs: rewrite README for v1.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This is the problem that gets worse in the AI era. An agent scaffolding a new se
 
 ```toml
 [dependencies]
-socle = "0.1"
+socle = "1.2"
 ```
 
 ```rust
@@ -90,24 +90,61 @@ Every service gets `/health/live` and `/health/ready` automatically. No routes t
 
 ```
 GET /health/live
-→ 200 { "status": "pass", "version": "1.2.3", "service_id": "billing-service" }
+→ 200 { "status": "pass", "version": "1.2.0", "service_id": "billing-service" }
 
 GET /health/ready
 → 200 { "db": [{ "status": "pass" }] }
 → 503 { "db": [{ "status": "fail", "output": "connection refused" }] }
 ```
 
-Register dependency checks with `with_readiness_check`:
+Register dependency checks with `with_readiness_check` or implement the `HealthProbe` trait:
 
 ```rust
 use socle::ServiceBootstrap;
-use api_bones::health::HealthCheck;
 
 ServiceBootstrap::new("billing-service")
-    .with_readiness_check("database", || async {
-        // probe your pool here
-        HealthCheck::pass("database")
+    .with_readiness_check("cache", || async {
+        // probe your cache here
+        api_bones::health::HealthCheck::pass("cache")
     });
+```
+
+### Database + migrations
+
+Connect to Postgres and optionally run sqlx migrations at startup. The pool is available in the router builder via `ctx.db()`.
+
+```rust
+use socle::{ServiceBootstrap, BootstrapCtx, Result};
+use axum::{Router, routing::get, extract::State};
+use sqlx::PgPool;
+
+sqlx::migrate!("./migrations"); // generates a static Migrator
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    ServiceBootstrap::new("billing-service")
+        .with_telemetry()
+        .with_database("postgres://localhost/billing")
+        .with_migrations(sqlx::migrate!())
+        .with_router(|ctx: &BootstrapCtx| {
+            let pool = ctx.db().clone();
+            Router::new()
+                .route("/orders", get(list_orders))
+                .with_state(pool)
+        })
+        .serve("0.0.0.0:8080")
+        .await
+}
+
+async fn list_orders(State(pool): State<PgPool>) -> &'static str { "[]" }
+```
+
+If you already own the pool (connection string fetched from a secrets manager, custom connection options, etc.), pass it directly:
+
+```rust
+let pool = PgPool::connect_with(options).await?;
+ServiceBootstrap::new("billing-service")
+    .with_db_pool(pool);
 ```
 
 ### Rate limiting with zero boilerplate
@@ -142,7 +179,7 @@ retry-after: 42
 
 ### Graceful shutdown with drain hooks
 
-Register async callbacks that run after the HTTP server stops accepting connections, before the process exits. Hooks run in reverse registration order.
+Register async callbacks that run after the HTTP server stops accepting connections, before the process exits. Hooks run in reverse registration order, each with its own deadline.
 
 ```rust
 use std::time::Duration;
@@ -191,6 +228,131 @@ ServiceBootstrap::new("orders-service")
     .with_openapi_paths("/openapi.json", "/docs");
 ```
 
+### Handler errors — RFC 9457 Problem+JSON throughout
+
+`HandlerError` is the standard error type for axum handlers. It serializes as `application/problem+json` and maps sqlx errors for you.
+
+```rust
+use socle::{HandlerError, HandlerResponse};
+use axum::http::StatusCode;
+use api_bones::ApiResponse;
+
+async fn get_order(/* ... */) -> HandlerResponse<Order> {
+    let row = sqlx::query_as!(Order, "SELECT * FROM orders WHERE id = $1", id)
+        .fetch_one(&pool)
+        .await
+        .map_err(|e| HandlerError::from_sqlx(&e))?; // RowNotFound → 404, unique → 409
+
+    Ok(socle::ok(row))
+}
+```
+
+The `ok`, `created`, and `listed` helpers build typed `ApiResponse` envelopes:
+
+```rust
+Ok(socle::ok(order))                   // 200 with ApiResponse<Order>
+Ok(socle::created(order))              // 201 with ApiResponse<Order>
+Ok(socle::listed(paginated_response))  // 200 with ApiResponse<PaginatedResponse<Order>>
+```
+
+### ETags and conditional updates
+
+Derive a weak ETag from a row's `updated_at` timestamp and validate `If-Match` headers before mutation:
+
+```rust
+use socle::{etag_from_updated_at, check_if_match, EtaggedHandlerResponse};
+use axum::http::HeaderMap;
+
+async fn update_order(
+    headers: HeaderMap,
+    // ...
+) -> EtaggedHandlerResponse<Order> {
+    let order = fetch_order(id).await?;
+    let etag = etag_from_updated_at(order.updated_at);
+    check_if_match(&headers, &etag)?; // 412 if stale
+
+    let updated = apply_patch(order, patch).await?;
+    Ok((etag_from_updated_at(updated.updated_at), StatusCode::OK, Json(ok(updated))))
+}
+```
+
+### Input validation
+
+The `Valid<T>` extractor (feature `validation`) runs `validator` field validations before the handler is invoked. Invalid requests get a 422 with per-field error details automatically.
+
+```rust
+use socle::Valid;
+use serde::Deserialize;
+use validator::Validate;
+
+#[derive(Deserialize, Validate)]
+struct CreateOrder {
+    #[validate(length(min = 1, max = 100))]
+    description: String,
+    #[validate(range(min = 1))]
+    quantity: u32,
+}
+
+async fn create_order(Valid(body): Valid<CreateOrder>) -> impl IntoResponse {
+    // body is already validated; invalid requests never reach here
+}
+```
+
+### Outgoing HTTP client with trace propagation
+
+The `http-client` feature provides a `reqwest`-based client that automatically forwards `x-request-id` and OpenTelemetry trace headers on every outgoing call — no manual header threading.
+
+```rust
+use socle::http_client;
+use std::time::Duration;
+
+let client = http_client::builder()
+    .timeout(Duration::from_secs(10))
+    .connect_timeout(Duration::from_secs(2))
+    .user_agent("billing-service/1.0")
+    .build()?;
+
+let resp = client.get("https://inventory-service/items/42").send().await?;
+```
+
+### RED metrics via Prometheus
+
+The `metrics` feature provides a Tower layer that records request count, latency, and error rate per route/method/status against a Prometheus registry. Mount it alongside your existing `/metrics` endpoint.
+
+```rust
+use socle::metrics::MetricsLayer;
+use prometheus::Registry;
+
+let registry = Registry::new();
+let layer = MetricsLayer::new(registry.clone())?;
+
+ServiceBootstrap::new("billing-service")
+    .with_layer(move |router| router.layer(layer.clone()));
+```
+
+You can also create named counters from the global OpenTelemetry meter:
+
+```rust
+use socle::metrics::counter;
+
+let processed = counter("orders_processed_total");
+processed.add(1, &[]);
+```
+
+### Opaque pagination cursors
+
+The `cursor` feature provides HMAC-signed, base64-encoded cursors for keyset pagination. Cursors are opaque to clients and tamper-evident.
+
+```rust
+use socle::Cursor;
+
+// Encode a cursor from any serializable position
+let cursor = Cursor::encode(&last_row_id, &secret_key)?;
+
+// Decode and verify on the next request
+let position: Uuid = cursor.decode(&secret_key)?;
+```
+
 ### Escape hatches for wrapper crates
 
 Inject arbitrary tower layers and access the fully-constructed context in the router builder. This is how `service-kit` and other internal wrapper crates extend socle without forking `serve()`.
@@ -203,9 +365,102 @@ ServiceBootstrap::new("platform-service")
     .with_layer(|router| router.layer(my_auth_layer()))
     .with_layer(|router| router.layer(my_tracing_enrichment_layer()))
     .with_router(|ctx: &BootstrapCtx| {
-        let pool = ctx.db.clone(); // sqlx::PgPool, if database feature enabled
+        // Store and retrieve arbitrary typed values injected by wrapper crates
+        let tenant_config = ctx.get::<TenantConfig>();
         Router::new()
     });
+```
+
+Four port traits give wrapper crates structured extension points:
+
+| Trait | Purpose |
+|-------|---------|
+| `TelemetryProvider` | Custom OTel SDK initialisation and flush on shutdown |
+| `AuthProvider` | Inject a JWT / JWKS / API-key / mTLS auth layer |
+| `RateLimitProvider` | Replace the in-process limiter with a Redis or Postgres backend |
+| `HealthProbe` | Typed readiness check with a `name()` and async `check()` |
+
+## Testing
+
+### Ephemeral HTTP test server
+
+The `testing` feature provides `TestApp` — a real Axum server bound to an ephemeral port. Use it in integration tests to exercise the full handler stack with actual HTTP.
+
+```toml
+[dev-dependencies]
+socle = { version = "1.2", features = ["testing"] }
+```
+
+```rust
+use socle::testing::{TestApp, TestClient};
+use axum::{Router, routing::get};
+
+#[tokio::test]
+async fn test_list_orders() {
+    let app = TestApp::builder()
+        .router(Router::new().route("/orders", get(|| async { "[]" })))
+        .build()
+        .await;
+
+    let client = app.client();
+    let resp = client.get("/orders").await;
+
+    assert_eq!(resp.status(), 200);
+    app.shutdown().await;
+}
+```
+
+`TestClient` wraps `reqwest` and is pre-pointed at the test server's address. Call `.get(path)`, `.post(path, &body)`, etc. without managing base URLs.
+
+### Ephemeral Postgres
+
+The `testing-postgres` feature spins up a real Postgres 16 container (via `testcontainers`) and tears it down when the test completes. No test database configuration to manage.
+
+```toml
+[dev-dependencies]
+socle = { version = "1.2", features = ["testing-postgres"] }
+```
+
+```rust
+use socle::testing::EphemeralPostgres;
+
+#[tokio::test]
+async fn test_with_real_database() {
+    let pg = EphemeralPostgres::start().await;
+    let pool = pg.pool().await;
+
+    sqlx::query("CREATE TABLE orders (id BIGSERIAL PRIMARY KEY)")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+    // run your repository code against a real database
+}
+```
+
+`EphemeralPostgres` also exposes `connection_url()` if you need to pass the URL to a migration tool or a `ServiceBootstrap` under test.
+
+### In-memory span capture
+
+Assert on tracing spans emitted by your handlers without shipping anything to an OTel collector.
+
+```rust
+use socle::testing::{init_capture_tracing, CaptureExporter};
+
+#[tokio::test]
+async fn test_spans_emitted() {
+    let exporter = init_capture_tracing();
+
+    // run code that emits spans
+    do_something_instrumented().await;
+
+    let spans = exporter.drain();
+    assert!(spans.iter().any(|s| s.name == "orders.list"));
+
+    // SpanRecord exposes name: String and attributes: Vec<(String, String)>
+    let span = &spans[0];
+    assert_eq!(span.attributes.iter().find(|(k, _)| k == "db.system"), Some(&("db.system".into(), "postgresql".into())));
+}
 ```
 
 ## Builder reference
@@ -215,7 +470,7 @@ ServiceBootstrap::new("platform-service")
 | Method | Description | Default |
 |--------|-------------|---------|
 | `new(name)` | Start a new bootstrap | — |
-| `from_config(name, cfg)` | Build from a [`BootstrapConfig`] | — |
+| `from_config(name, cfg)` | Build from a `BootstrapConfig` | — |
 | `serve(addr)` | Bind and run until signal | — |
 | `serve_with_shutdown(listener, future)` | Run with a caller-supplied shutdown future | — |
 | `run()` | Run using `bind_addr` from `from_config` | — |
@@ -224,7 +479,7 @@ ServiceBootstrap::new("platform-service")
 | `with_body_limit(bytes)` | Max request body size | `2 MiB` |
 | `with_shutdown_timeout(d)` | Graceful shutdown deadline | `30s` |
 | `with_shutdown_hook(name, timeout, f)` | Register an async drain callback | — |
-| `with_readiness_check(name, f)` | Register a readiness probe | — |
+| `with_readiness_check(name, f)` | Register a readiness probe closure | — |
 | `with_health_probe(probe)` | Register a typed `HealthProbe` | — |
 | `with_router(f)` | Provide the axum router builder closure | — |
 | `with_layer(f)` | Inject an arbitrary tower layer | — |
@@ -234,14 +489,15 @@ ServiceBootstrap::new("platform-service")
 | Method | Description |
 |--------|-------------|
 | `with_telemetry()` | Enable `tracing-subscriber` JSON/pretty setup |
-| `with_telemetry_init(f)` | Override the telemetry init function (e.g. full OTel SDK) |
+| `with_telemetry_init(f)` | Override the telemetry init function |
+| `with_telemetry_provider(p)` | Plug in a custom `TelemetryProvider` (full OTel SDK init + shutdown) |
 
 ### Database (`database` feature)
 
 | Method | Description |
 |--------|-------------|
 | `with_database(url)` | Connect to Postgres and build a `PgPool` |
-| `with_db_pool(pool)` | Provide a pre-built `PgPool` (takes precedence over `with_database`) |
+| `with_db_pool(pool)` | Provide a pre-built `PgPool` |
 | `with_migrations(migrator)` | Run sqlx migrations at startup |
 
 ### Rate limiting (`ratelimit-memory` feature)
@@ -250,6 +506,7 @@ ServiceBootstrap::new("platform-service")
 |--------|-------------|
 | `with_rate_limit(backend)` | Enable in-process GCRA rate limiting |
 | `with_rate_limit_extractor(e)` | Override the key extractor (default: remote IP) |
+| `with_rate_limit_provider(p)` | Plug in a distributed `RateLimitProvider` |
 
 `RateLimitExtractor` variants:
 
@@ -258,27 +515,34 @@ ServiceBootstrap::new("platform-service")
 | `Ip` (default) | L4 remote address — use `Header("x-forwarded-for")` behind a proxy |
 | `Header(name)` | Arbitrary request header value |
 
+### Auth
+
+| Method | Description |
+|--------|-------------|
+| `with_auth_provider(p)` | Plug in a custom `AuthProvider` (JWT, JWKS, API-key, OIDC, mTLS) |
+
 ### CORS
 
 | Method | Description |
 |--------|-------------|
 | `with_cors(layer)` | Provide a raw `tower_http::cors::CorsLayer` |
-| `with_cors_config(cfg)` | Configure CORS from a structured [`CorsConfig`] |
+| `with_cors_config(cfg)` | Configure CORS from a structured `CorsConfig` |
 
 ### OpenAPI (`openapi` feature)
 
 | Method | Description |
 |--------|-------------|
 | `with_openapi(api)` | Mount a utoipa `OpenApi` spec and Swagger UI |
-| `with_openapi_paths(spec, ui)` | Override the spec and UI mount paths |
+| `with_openapi_paths(spec, ui)` | Override the spec and UI mount paths (defaults: `/openapi.json`, `/docs`) |
 
 ### Config (file + env)
 
-| Method | Description |
+| Method / function | Description |
 |--------|-------------|
 | `BootstrapConfig::from_env()` | Load from `SOCLE_*` env vars |
 | `BootstrapConfig::load(path)` | Load from TOML file with env-var overrides |
 | `BootstrapConfig::validate()` | Validate cross-field invariants |
+| `ServiceBootstrap::with_dotenv()` | Load `.env` file before config resolution (`dotenv` feature) |
 
 Environment variables honored automatically:
 
@@ -295,20 +559,20 @@ Environment variables honored automatically:
 
 ## Middleware stack
 
-Layers are applied in this order, outermost first (i.e. request processing goes top-to-bottom, response bottom-to-top):
+Layers are applied in this order, outermost first (request processing goes top-to-bottom, response bottom-to-top):
 
 | Layer | Always? | Notes |
 |-------|---------|-------|
-| `SetRequestIdLayer` | ✓ | Generates `x-request-id` (UUID v7) if absent |
-| `RequestIdTaskLocalLayer` | ✓ | Propagates request ID to a task-local for logging |
+| `SetRequestIdLayer` | ✓ | Generates `x-request-id` (UUIDv7) if absent; accepts inbound `x-request-id` / `x-correlation-id` |
+| `RequestIdTaskLocalLayer` | ✓ | Propagates request ID to a task-local for log enrichment |
 | `PropagateRequestIdLayer` | ✓ | Copies `x-request-id` to responses |
-| `TraceLayer` | ✓ | `tracing` span per request with method, URI, request ID |
+| `TraceLayer` | ✓ | `tracing` span per request with method, URI, and request ID |
 | `CatchPanicLayer` | ✓ | Returns 500 on handler panics; does not echo panic payload |
 | `CorsLayer` | opt-in | Only when `with_cors_config()` / `with_cors()` is called |
 | `RequestBodyLimitLayer` | ✓ | Rejects bodies over `body_limit_bytes` (default 2 MiB) |
 | `CompressionLayer` | ✓ | gzip / br / zstd response compression |
 | `enrich_error_response` | ✓ | Upgrades bare 4xx/5xx bodies to RFC 9457 Problem+JSON |
-| Extra layers (via `with_layer`) | opt-in | Applied innermost first |
+| Extra layers (via `with_layer`) | opt-in | Applied innermost-first; this is where `AuthProvider` and `RateLimitProvider` inject |
 | `RateLimitLayer` | opt-in | GCRA limiter, only when `with_rate_limit()` is called |
 | User router | ✓ | Routes registered via `with_router()` |
 | Health router | ✓ | `/health/live`, `/health/ready` |
@@ -323,10 +587,13 @@ Layers are applied in this order, outermost first (i.e. request processing goes 
 | `ratelimit-memory` | ✓ | In-process GCRA rate limiter via `governor` |
 | `openapi` | ✓ | utoipa OpenAPI spec + Swagger UI |
 | `dotenv` | ✓ | `.env` file loading via `dotenvy` |
-| `ratelimit` | — | Rate-limit types only (no backend) |
-| `validation` | — | `Valid<T>` extractor via `validator` |
+| `ratelimit` | — | Rate-limit types and traits only (no backend) |
+| `validation` | — | `Valid<T>` extractor with per-field 422 errors via `validator` |
 | `cursor` | — | HMAC-signed opaque pagination cursors |
-| `testing` | — | `reqwest`-based test helpers |
+| `http-client` | — | Outgoing HTTP client with automatic trace/request-ID propagation |
+| `metrics` | — | RED metrics Tower layer + Prometheus registry integration |
+| `testing` | — | `TestApp` ephemeral server + `TestClient` + `CaptureExporter` |
+| `testing-postgres` | — | `EphemeralPostgres` Docker-backed Postgres for integration tests |
 
 ## Prior art
 
@@ -340,7 +607,7 @@ Three things socle does that the alternatives don't:
 
 - **Correct layer ordering, always.** Rate-limiting wraps auth wraps the user router wraps telemetry — in that order, enforced by the builder, not documented somewhere and hoped for.
 - **Per-hook shutdown timeouts with drain ordering.** Hooks run in reverse registration order; each has its own deadline. Getting this right in every service individually is the kind of thing that fails silently in production.
-- **Port traits for wrapper crates.** `AuthProvider` and `RateLimitProvider` let internal platforms extend socle without forking `serve()`. Add your JWT layer, your distributed rate limiter, your org-context middleware — socle stays upgradeable.
+- **Port traits for wrapper crates.** `AuthProvider`, `RateLimitProvider`, `TelemetryProvider`, and `HealthProbe` let internal platforms extend socle without forking `serve()`. Add your JWT layer, your distributed rate limiter, your org-context middleware — socle stays upgradeable.
 
 ## MSRV
 


### PR DESCRIPTION
## Summary

- Rewrites the README to document all features introduced since the initial release, including `testing`, `testing-postgres`, `http-client`, `metrics`, `validation`, `cursor`, and the four port traits
- Adds a dedicated Testing section covering `TestApp`, `EphemeralPostgres`, and `CaptureExporter` with worked examples
- Bumps the dependency example to `"1.2"` and fills in missing builder reference rows (`with_auth_provider`, `with_rate_limit_provider`, `with_telemetry_provider`, `with_dotenv`)

## Test plan

- [ ] README renders correctly on GitHub
- [ ] All code snippets compile against the current API
- [ ] Feature table matches `Cargo.toml` feature list

🤖 Generated with [Claude Code](https://claude.com/claude-code)