### PR TITLE
chore: release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [1.2.1] — 2026-04-24
+
+### Changed
+
+- Bumped `opentelemetry_sdk` and `opentelemetry-prometheus` from `0.29` to `0.31`.
+
 ## [1.2.0] — 2026-04-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1902,20 +1902,6 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "opentelemetry"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e87237e2775f74896f9ad219d26a2081751187eb7c9f5c58dde20a23b95d16c"
-dependencies = [
- "futures-core",
- "futures-sink",
- "js-sys",
- "pin-project-lite",
- "thiserror 2.0.18",
- "tracing",
-]
-
-[[package]]
-name = "opentelemetry"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
@@ -1935,7 +1921,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14095eb06b569eb5d538fa4555969f7e8a410ed7910c903bfd295f9e1a50d7ea"
 dependencies = [
  "once_cell",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "opentelemetry_sdk",
  "prometheus",
  "tracing",
@@ -1950,7 +1936,7 @@ dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "opentelemetry 0.31.0",
+ "opentelemetry",
  "percent-encoding",
  "rand 0.9.4",
  "thiserror 2.0.18",
@@ -3008,7 +2994,7 @@ dependencies = [
  "governor",
  "http",
  "http-body-util",
- "opentelemetry 0.29.1",
+ "opentelemetry",
  "opentelemetry-prometheus",
  "opentelemetry_sdk",
  "prometheus",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1089,12 +1089,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "governor"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1921,13 +1915,27 @@ dependencies = [
 ]
 
 [[package]]
-name = "opentelemetry-prometheus"
-version = "0.29.1"
+name = "opentelemetry"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "098a71a4430bb712be6130ed777335d2e5b19bc8566de5f2edddfce906def6ab"
+checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "pin-project-lite",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "opentelemetry-prometheus"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14095eb06b569eb5d538fa4555969f7e8a410ed7910c903bfd295f9e1a50d7ea"
 dependencies = [
  "once_cell",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "opentelemetry_sdk",
  "prometheus",
  "tracing",
@@ -1935,20 +1943,17 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afdefb21d1d47394abc1ba6c57363ab141be19e27cc70d0e422b7f303e4d290b"
+checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
- "glob",
- "opentelemetry",
+ "opentelemetry 0.31.0",
  "percent-encoding",
  "rand 0.9.4",
- "serde_json",
  "thiserror 2.0.18",
- "tracing",
 ]
 
 [[package]]
@@ -2990,7 +2995,7 @@ dependencies = [
 
 [[package]]
 name = "socle"
-version = "1.2.0"
+version = "1.2.1"
 dependencies = [
  "api-bones",
  "async-trait",
@@ -3003,7 +3008,7 @@ dependencies = [
  "governor",
  "http",
  "http-body-util",
- "opentelemetry",
+ "opentelemetry 0.29.1",
  "opentelemetry-prometheus",
  "opentelemetry_sdk",
  "prometheus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ dotenvy = { version = "0.15", optional = true }
 
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"], optional = true }
 reqwest-middleware = { version = "0.5", optional = true }
-opentelemetry = { version = "0.29", optional = true }
+opentelemetry = { version = "0.31", optional = true }
 async-trait = { version = "0.1", optional = true }
 http = { version = "1", optional = true }
 opentelemetry_sdk = { version = "0.31", default-features = false, features = ["metrics"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "socle"
-version = "1.2.0"
+version = "1.2.1"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 description = "Opinionated axum service bootstrap: telemetry, database, rate limiting, and shutdown in one builder"
@@ -71,8 +71,8 @@ reqwest-middleware = { version = "0.5", optional = true }
 opentelemetry = { version = "0.29", optional = true }
 async-trait = { version = "0.1", optional = true }
 http = { version = "1", optional = true }
-opentelemetry_sdk = { version = "0.29", default-features = false, features = ["metrics"], optional = true }
-opentelemetry-prometheus = { version = "0.29", optional = true }
+opentelemetry_sdk = { version = "0.31", default-features = false, features = ["metrics"], optional = true }
+opentelemetry-prometheus = { version = "0.31", optional = true }
 prometheus = { version = "0.14", default-features = false, optional = true }
 
 validator = { version = "0.20", features = ["derive"], optional = true }
@@ -88,7 +88,7 @@ http-body-util = "0.1"
 bytes = "1"
 tempfile = "3"
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "postgres"] }
-opentelemetry_sdk = { version = "0.29", features = ["trace"] }
+opentelemetry_sdk = { version = "0.31", features = ["trace"] }
 
 [[example]]
 name = "minimal"


### PR DESCRIPTION
## Summary

- Bumped `opentelemetry_sdk` and `opentelemetry-prometheus` from `0.29` to `0.31`
- Updated `CHANGELOG.md` for v1.2.1

## Test plan

- [ ] CI passes
- [ ] `cargo publish` dry-run succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)