### PR TITLE
feat(handler): ok/created/listed return Result directly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [2.0.0] — 2026-04-24
+
+### Changed
+
+- **Breaking:** `ok()`, `created()`, and `listed()` now return `HandlerResponse<T>`, `CreatedResponse<T>`, and `HandlerListResponse<T>` respectively instead of bare tuples. Handlers that previously wrote `Ok(ok(value))` now write `ok(value)`. Callers that destructured the return value directly must add `.unwrap()` or handle the `Result`.
+
 ## [1.3.0] — 2026-04-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "socle"
-version = "1.3.0"
+version = "2.0.0"
 dependencies = [
  "api-bones",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "socle"
-version = "1.3.0"
+version = "2.0.0"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 description = "Opinionated axum service bootstrap: telemetry, database, rate limiting, and shutdown in one builder"

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This is the problem that gets worse in the AI era. An agent scaffolding a new se
 
 ```toml
 [dependencies]
-socle = "1.3"
+socle = "2.0"
 ```
 
 ```rust
@@ -388,7 +388,7 @@ The `testing` feature provides `TestApp` — a real Axum server bound to an ephe
 
 ```toml
 [dev-dependencies]
-socle = { version = "1.3", features = ["testing"] }
+socle = { version = "2.0", features = ["testing"] }
 ```
 
 ```rust
@@ -418,7 +418,7 @@ The `testing-postgres` feature spins up a real Postgres 16 container (via `testc
 
 ```toml
 [dev-dependencies]
-socle = { version = "1.3", features = ["testing-postgres"] }
+socle = { version = "2.0", features = ["testing-postgres"] }
 ```
 
 ```rust

--- a/src/handler_error.rs
+++ b/src/handler_error.rs
@@ -95,37 +95,25 @@ pub type EtaggedHandlerResponse<T> = Result<
     HandlerError,
 >;
 
-/// Build the success value for a [`CreatedResponse`] handler (201 Created).
-pub fn created<T>(
-    value: T,
-) -> (
-    axum::http::StatusCode,
-    axum::Json<api_bones::ApiResponse<T>>,
-) {
-    (
+/// Build the success response for a [`CreatedResponse`] handler (201 Created).
+pub fn created<T>(value: T) -> CreatedResponse<T> {
+    Ok((
         axum::http::StatusCode::CREATED,
         axum::Json(api_bones::ApiResponse::builder(value).build()),
-    )
+    ))
 }
 
-/// Build the success value for a [`HandlerResponse`] handler (200 OK).
-pub fn ok<T>(
-    value: T,
-) -> (
-    axum::http::StatusCode,
-    axum::Json<api_bones::ApiResponse<T>>,
-) {
-    (
+/// Build the success response for a [`HandlerResponse`] handler (200 OK).
+pub fn ok<T>(value: T) -> HandlerResponse<T> {
+    Ok((
         axum::http::StatusCode::OK,
         axum::Json(api_bones::ApiResponse::builder(value).build()),
-    )
+    ))
 }
 
-/// Build the success value for a [`HandlerListResponse`] handler.
-pub fn listed<T>(
-    page: api_bones::PaginatedResponse<T>,
-) -> axum::Json<api_bones::ApiResponse<api_bones::PaginatedResponse<T>>> {
-    axum::Json(api_bones::ApiResponse::builder(page).build())
+/// Build the success response for a [`HandlerListResponse`] handler.
+pub fn listed<T>(page: api_bones::PaginatedResponse<T>) -> HandlerListResponse<T> {
+    Ok(axum::Json(api_bones::ApiResponse::builder(page).build()))
 }
 
 /// Build a Problem+JSON 500 response from a panic payload. Used in catch-panic layer.
@@ -197,7 +185,7 @@ mod tests {
 
     #[test]
     fn created_builds_201_with_envelope() {
-        let (status, body) = created("x");
+        let (status, body) = created("x").unwrap();
         assert_eq!(status, axum::http::StatusCode::CREATED);
         let json = serde_json::to_value(body.0).unwrap();
         assert_eq!(json["data"], "x");
@@ -205,7 +193,7 @@ mod tests {
 
     #[test]
     fn ok_builds_200_with_envelope() {
-        let (status, body) = ok(42u32);
+        let (status, body) = ok(42u32).unwrap();
         assert_eq!(status, axum::http::StatusCode::OK);
         let json = serde_json::to_value(body.0).unwrap();
         assert_eq!(json["data"], 42);
@@ -216,7 +204,7 @@ mod tests {
         use api_bones::{PaginatedResponse, pagination::PaginationParams};
         let page: PaginatedResponse<u32> =
             PaginatedResponse::new(vec![1, 2], 2, &PaginationParams::default());
-        let body = listed(page);
+        let body = listed(page).unwrap();
         let json = serde_json::to_value(body.0).unwrap();
         assert_eq!(json["data"]["items"], serde_json::json!([1, 2]));
     }


### PR DESCRIPTION
## Summary

- `ok()`, `created()`, and `listed()` now return `HandlerResponse<T>`, `CreatedResponse<T>`, and `HandlerListResponse<T>` respectively
- Handlers write `ok(value)` instead of `Ok(ok(value))` — the double-wrap was pure noise
- Bumps to v2.0.0 (breaking: callers that destructured the bare tuple must add `.unwrap()`)

## Test plan

- [x] All 96 unit tests pass
- [x] `cargo clippy --workspace -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)