### PR TITLE
feat(handler_error): add etagged helper + release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [2.1.0] — 2026-04-24
+
+### Added
+
+- `etagged(etag, value)` — builder for [`EtaggedHandlerResponse`], mirrors `ok(v)` / `created(v)` / `listed(page)` ergonomics.
+
 ## [2.0.0] — 2026-04-24
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "socle"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "api-bones",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "socle"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 description = "Opinionated axum service bootstrap: telemetry, database, rate limiting, and shutdown in one builder"

--- a/src/handler_error.rs
+++ b/src/handler_error.rs
@@ -116,6 +116,15 @@ pub fn listed<T>(page: api_bones::PaginatedResponse<T>) -> HandlerListResponse<T
     Ok(axum::Json(api_bones::ApiResponse::builder(page).build()))
 }
 
+/// Build the success response for an [`EtaggedHandlerResponse`] handler (200 OK + ETag header).
+pub fn etagged<T>(etag: api_bones::etag::ETag, value: T) -> EtaggedHandlerResponse<T> {
+    Ok((
+        etag,
+        axum::http::StatusCode::OK,
+        axum::Json(api_bones::ApiResponse::builder(value).build()),
+    ))
+}
+
 /// Build a Problem+JSON 500 response from a panic payload. Used in catch-panic layer.
 pub(crate) fn panic_handler(err: Box<dyn std::any::Any + Send + 'static>) -> Response {
     let detail = if let Some(s) = err.downcast_ref::<String>() {
@@ -197,6 +206,17 @@ mod tests {
         assert_eq!(status, axum::http::StatusCode::OK);
         let json = serde_json::to_value(body.0).unwrap();
         assert_eq!(json["data"], 42);
+    }
+
+    #[test]
+    fn etagged_builds_200_with_etag_and_envelope() {
+        use api_bones::etag::ETag;
+        let etag = ETag::strong("abc123");
+        let (out_etag, status, body) = etagged(etag.clone(), 99u32).unwrap();
+        assert_eq!(out_etag, etag);
+        assert_eq!(status, axum::http::StatusCode::OK);
+        let json = serde_json::to_value(body.0).unwrap();
+        assert_eq!(json["data"], 99);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,7 +52,8 @@ pub use error::{Error, Result};
 pub use etag::{ETag, IfMatch, IfNoneMatch, check_if_match, etag_from_updated_at};
 pub use handler_error::{
     ApiError, CreatedResponse, ErrorCode, EtaggedHandlerResponse, HandlerError,
-    HandlerListResponse, HandlerResponse, ProblemJson, ValidationError, created, listed, ok,
+    HandlerListResponse, HandlerResponse, ProblemJson, ValidationError, created, etagged, listed,
+    ok,
 };
 pub use pagination::{
     CursorPaginatedResponse, CursorPagination, CursorPaginationParams, KeysetPaginatedResponse,


### PR DESCRIPTION
## Summary

- Adds `etagged(etag, value)` builder for `EtaggedHandlerResponse<T>`, matching `ok(v)` / `created(v)` / `listed(page)` ergonomics.
- Re-exports `etagged` from the crate root via `pub use handler_error::{..}` in `src/lib.rs`.
- Unit test asserting ETag equality, 200 status, and JSON envelope `data` field.
- Bumps version `2.0.0 → 2.1.0` in `Cargo.toml`.
- `### Added` entry under `[2.1.0]` in `CHANGELOG.md`.

Closes #32

## Test plan

- [x] `cargo build` — clean (compiles as `socle v2.1.0`)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test --lib` — 97 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)