### PR TITLE
fix: EtaggedHandlerResponse tuple order + etagged() helper (v2.2.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+## [2.2.0] — 2026-04-24
+
+### Fixed
+
+- `EtaggedHandlerResponse<T>` tuple order corrected to `(StatusCode, ETag, Json<ApiResponse<T>>)` — axum 0.8 requires `StatusCode` as the first element; the previous `(ETag, StatusCode, Json<...>)` order caused the `Handler` trait bound to fail at call sites.
+- `etagged(etag, value)` return tuple updated to match.
+
 ## [2.1.0] — 2026-04-24
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "socle"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "api-bones",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "socle"
-version = "2.1.0"
+version = "2.2.0"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 description = "Opinionated axum service bootstrap: telemetry, database, rate limiting, and shutdown in one builder"

--- a/src/handler_error.rs
+++ b/src/handler_error.rs
@@ -88,8 +88,8 @@ pub type CreatedResponse<T> = Result<
 /// Return type for read/update handlers that carry an ETag response header.
 pub type EtaggedHandlerResponse<T> = Result<
     (
-        api_bones::etag::ETag,
         axum::http::StatusCode,
+        api_bones::etag::ETag,
         axum::Json<api_bones::ApiResponse<T>>,
     ),
     HandlerError,
@@ -119,8 +119,8 @@ pub fn listed<T>(page: api_bones::PaginatedResponse<T>) -> HandlerListResponse<T
 /// Build the success response for an [`EtaggedHandlerResponse`] handler (200 OK + ETag header).
 pub fn etagged<T>(etag: api_bones::etag::ETag, value: T) -> EtaggedHandlerResponse<T> {
     Ok((
-        etag,
         axum::http::StatusCode::OK,
+        etag,
         axum::Json(api_bones::ApiResponse::builder(value).build()),
     ))
 }
@@ -212,9 +212,9 @@ mod tests {
     fn etagged_builds_200_with_etag_and_envelope() {
         use api_bones::etag::ETag;
         let etag = ETag::strong("abc123");
-        let (out_etag, status, body) = etagged(etag.clone(), 99u32).unwrap();
-        assert_eq!(out_etag, etag);
+        let (status, out_etag, body) = etagged(etag.clone(), 99u32).unwrap();
         assert_eq!(status, axum::http::StatusCode::OK);
+        assert_eq!(out_etag, etag);
         let json = serde_json::to_value(body.0).unwrap();
         assert_eq!(json["data"], 99);
     }


### PR DESCRIPTION
## Summary

- Add `etagged(etag, value)` helper mirroring `ok()`/`created()`/`listed()` ergonomics for `EtaggedHandlerResponse<T>` handlers
- Fix tuple order: axum 0.8 requires `StatusCode` as the first element — the previous `(ETag, StatusCode, Json<...>)` caused the `Handler` trait bound to fail at all ETag handler call sites
- Releases as **socle 2.2.0**

## Test plan

- [x] Unit tests updated to match corrected tuple order
- [x] `cargo test` passes
- [x] `cargo clippy -D warnings` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)