### PR TITLE
fix(openapi): vendor utoipa-swagger-ui assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [2.3.1] — 2026-04-24
+
+### Fixed
+
+- `openapi` feature: add `vendored` to `utoipa-swagger-ui` dependency so Swagger UI assets are bundled at compile time rather than downloaded from GitHub at build time — prevents build failures in air-gapped CI environments.
+
 ## [2.3.0] — 2026-04-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "socle"
-version = "2.3.0"
+version = "2.3.1"
 dependencies = [
  "api-bones",
  "async-trait",
@@ -3903,8 +3903,15 @@ dependencies = [
  "serde",
  "serde_json",
  "utoipa",
+ "utoipa-swagger-ui-vendored",
  "zip",
 ]
+
+[[package]]
+name = "utoipa-swagger-ui-vendored"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2eebbbfe4093922c2b6734d7c679ebfebd704a0d7e56dfcb0d05818ce28977d"
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "socle"
-version = "2.3.0"
+version = "2.3.1"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 description = "Opinionated axum service bootstrap: telemetry, database, rate limiting, and shutdown in one builder"
@@ -62,7 +62,7 @@ sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-r
 governor = { version = "0.10", default-features = false, features = ["std", "dashmap"], optional = true }
 
 utoipa = { version = "5", optional = true }
-utoipa-swagger-ui = { version = "9", default-features = false, features = ["axum"], optional = true }
+utoipa-swagger-ui = { version = "9", default-features = false, features = ["axum", "vendored"], optional = true }
 
 dotenvy = { version = "0.15", optional = true }
 


### PR DESCRIPTION
## Summary

- Add `vendored` feature to the `utoipa-swagger-ui` dependency in the `openapi` feature group
- Swagger UI assets are now bundled at compile time instead of downloaded from GitHub during the build script
- Prevents build failures on CI runners without outbound internet access (curl error 92)

## Test plan

- `cargo check` passes with the `openapi` feature enabled
- Bumped to `2.3.1` with CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)