### PR TITLE
feat: add listed_page() client-side pagination helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+## [2.4.0] — 2026-04-24
+
+### Added
+
+- `listed_page<T, U>(items, params)` — ergonomic helper that paginates a fully-loaded `Vec<T>`, maps each item to `U` via `Into`, and returns a `HandlerListResponse<U>`. Eliminates the skip/take/total boilerplate repeated across client-side pagination handlers.
+
 ## [2.3.1] — 2026-04-24
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2981,7 +2981,7 @@ dependencies = [
 
 [[package]]
 name = "socle"
-version = "2.3.1"
+version = "2.4.0"
 dependencies = [
  "api-bones",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "socle"
-version = "2.3.1"
+version = "2.4.0"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 description = "Opinionated axum service bootstrap: telemetry, database, rate limiting, and shutdown in one builder"

--- a/src/handler_error.rs
+++ b/src/handler_error.rs
@@ -116,6 +116,37 @@ pub fn listed<T>(page: api_bones::PaginatedResponse<T>) -> HandlerListResponse<T
     Ok(axum::Json(api_bones::ApiResponse::builder(page).build()))
 }
 
+/// Paginate a fully-loaded `Vec<T>`, map each item to `U`, and return a [`HandlerListResponse`].
+///
+/// Combines the common client-side pagination boilerplate (skip/take + total) into one call:
+///
+/// ```rust,no_run
+/// use socle::{HandlerListResponse, listed_page};
+/// use socle::pagination::PaginationParams;
+///
+/// async fn list_items(params: PaginationParams) -> HandlerListResponse<String> {
+///     let all: Vec<String> = vec!["a".into(), "b".into()];
+///     listed_page(all, &params)
+/// }
+/// ```
+pub fn listed_page<T, U>(
+    items: Vec<T>,
+    params: &api_bones::pagination::PaginationParams,
+) -> HandlerListResponse<U>
+where
+    T: Into<U>,
+    U: serde::Serialize,
+{
+    let total = items.len() as u64;
+    let page: Vec<U> = items
+        .into_iter()
+        .skip(params.offset.unwrap_or(0) as usize)
+        .take(params.limit.unwrap_or(20) as usize)
+        .map(Into::into)
+        .collect();
+    listed(api_bones::PaginatedResponse::new(page, total, params))
+}
+
 /// Build the success response for an [`EtaggedHandlerResponse`] handler (200 OK + ETag header).
 pub fn etagged<T>(etag: api_bones::etag::ETag, value: T) -> EtaggedHandlerResponse<T> {
     Ok((
@@ -227,5 +258,28 @@ mod tests {
         let body = listed(page).unwrap();
         let json = serde_json::to_value(body.0).unwrap();
         assert_eq!(json["data"]["items"], serde_json::json!([1, 2]));
+    }
+
+    #[test]
+    fn listed_page_maps_and_paginates() {
+        use api_bones::pagination::PaginationParams;
+        let items: Vec<u32> = (1..=5).collect();
+        let params = PaginationParams {
+            offset: Some(1),
+            limit: Some(2),
+        };
+        let body = listed_page::<u32, u64>(items, &params).unwrap();
+        let json = serde_json::to_value(body.0).unwrap();
+        assert_eq!(json["data"]["items"], serde_json::json!([2, 3]));
+    }
+
+    #[test]
+    fn listed_page_uses_defaults_when_params_are_none() {
+        use api_bones::pagination::PaginationParams;
+        let items: Vec<u32> = (1..=25).collect();
+        let params = PaginationParams::default();
+        let body = listed_page::<u32, u64>(items, &params).unwrap();
+        let json = serde_json::to_value(body.0).unwrap();
+        assert_eq!(json["data"]["items"].as_array().unwrap().len(), 20);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,7 +53,7 @@ pub use etag::{ETag, IfMatch, IfNoneMatch, check_if_match, etag_from_updated_at}
 pub use handler_error::{
     ApiError, CreatedResponse, ErrorCode, EtaggedHandlerResponse, HandlerError,
     HandlerListResponse, HandlerResponse, ProblemJson, ValidationError, created, etagged, listed,
-    ok,
+    listed_page, ok,
 };
 pub use pagination::{
     CursorPaginatedResponse, CursorPagination, CursorPaginationParams, KeysetPaginatedResponse,


### PR DESCRIPTION
## Summary

- Adds `listed_page<T, U>(items, params)` — paginates a fully-loaded `Vec<T>`, maps each item to `U` via `Into`, returns `HandlerListResponse<U>`
- Re-exports from crate root (`socle::listed_page`)
- Bumps to v2.4.0 (minor — new public API)

Closes brefwiz/service-kit#170

## Test plan

- [x] `listed_page_maps_and_paginates` — verifies skip/take with explicit offset+limit
- [x] `listed_page_uses_defaults_when_params_are_none` — verifies default limit=20 applies
- [x] `cargo clippy --all-features -- -D warnings` clean
- [x] All 99 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)