### PR TITLE
feat(middleware): org isolation extractor + policy enforcement layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Added
+
+- `OrgContextExtractor` — Axum `FromRequestParts` extractor that resolves `OrganizationContext` from a principal extension or `X-Org-Id`/`X-Org-Path` headers, with cross-tenant conflict detection.
+- `OrgIsolationLayer` — Tower middleware that short-circuits with `401 Unauthorized` when `OrganizationContext` is absent from request extensions.
+- `OrgContextSource` — enum recording which mechanism resolved the org context (`PrincipalClaim` or `Header`).
+- `OrgPolicy` trait + `AncestryOrgPolicy` — policy trait for org-scoped access control, with a default ancestry-based implementation.
+
 ## [2.4.0] — 2026-04-24
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,3 +109,11 @@ required-features = ["telemetry", "ratelimit-memory"]
 name = "integration"
 path = "tests/integration.rs"
 required-features = ["testing"]
+
+[[test]]
+name = "org_isolation"
+path = "tests/org_isolation.rs"
+
+[[test]]
+name = "org_policy"
+path = "tests/org_policy.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,12 @@
 //! shutdown in one builder. Public open-source facade extracted from an internal
 //! service kit.
 //!
+//! ## Recommended middleware ordering
+//!
+//! ```text
+//! RequestIdLayer → auth (placeholder) → OrgIsolationLayer → rate-limit → audit → handler
+//! ```
+//!
 //! ```rust,no_run
 //! use socle::{ServiceBootstrap, BootstrapCtx, Result};
 //! use axum::{Router, routing::get};
@@ -31,6 +37,9 @@ mod error;
 mod handler_error;
 mod request_id;
 
+pub mod org_isolation;
+pub mod org_policy;
+
 pub mod etag;
 pub mod extract;
 pub mod pagination;
@@ -55,6 +64,11 @@ pub use handler_error::{
     HandlerListResponse, HandlerResponse, ProblemJson, ValidationError, created, etagged, listed,
     listed_page, ok,
 };
+pub use org_isolation::{
+    OrgContextExtractor, OrgContextSource, OrgIsolationLayer, OrgIsolationService,
+};
+pub use org_policy::{AncestryOrgPolicy, OrgPolicy};
+
 pub use pagination::{
     CursorPaginatedResponse, CursorPagination, CursorPaginationParams, KeysetPaginatedResponse,
     KeysetPaginationParams, PaginatedResponse, PaginationParams, SortDirection, SortParams,
@@ -76,6 +90,9 @@ pub use ports::rate_limit::RateLimitProvider;
 pub use ports::telemetry::{BasicTelemetryProvider, TelemetryProvider};
 
 // ── api-bones re-exports ──────────────────────────────────────────────────────
+
+pub use api_bones::org_context::OrganizationContext;
+pub use api_bones::org_id::{OrgId, OrgPath};
 
 pub use api_bones::common::{ResourceId, Timestamp};
 pub use api_bones::ratelimit::RateLimitInfo;

--- a/src/org_isolation.rs
+++ b/src/org_isolation.rs
@@ -1,0 +1,160 @@
+//! Org isolation extractor and enforcement middleware.
+//!
+//! # Middleware ordering
+//!
+//! See [`crate`] module doc for the recommended stack.
+
+use axum::extract::FromRequestParts;
+use axum::http::request::Parts;
+use axum::response::{IntoResponse, Response};
+use std::future::Future;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tower::{Layer, Service};
+
+use api_bones::error::ApiError;
+use api_bones::org_context::OrganizationContext;
+use api_bones::org_id::{OrgId, OrgPath};
+use api_bones::request_id::RequestId;
+
+use crate::handler_error::HandlerError;
+
+// ── OrgContextSource ─────────────────────────────────────────────────────────
+
+/// Records which mechanism resolved the [`OrganizationContext`] for this request.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum OrgContextSource {
+    /// Resolved from an authenticated principal extension (auth layer).
+    PrincipalClaim,
+    /// Resolved from the `X-Org-Id` / `X-Org-Path` headers.
+    Header,
+}
+
+// ── OrgContextExtractor ───────────────────────────────────────────────────────
+
+/// Axum extractor that resolves [`OrganizationContext`] from the request.
+///
+/// Resolution order:
+/// 1. Principal extension (`OrganizationContext` inserted by auth layer).
+/// 2. `X-Org-Id` header parsed via [`OrgId::try_from_headers`].
+/// 3. Reject with `401 Unauthorized` when neither yields an org.
+///
+/// When both (1) and (2) are present and their `org_id` disagrees the extractor
+/// rejects with `403 Forbidden` and emits a `tracing::warn!`.
+///
+/// On success the `OrganizationContext` and [`OrgContextSource`] are inserted
+/// into request extensions so downstream middleware (e.g. [`OrgIsolationLayer`])
+/// can find them.
+#[derive(Debug)]
+pub struct OrgContextExtractor(pub OrganizationContext);
+
+impl<S: Send + Sync> FromRequestParts<S> for OrgContextExtractor {
+    type Rejection = HandlerError;
+
+    async fn from_request_parts(parts: &mut Parts, _state: &S) -> Result<Self, Self::Rejection> {
+        let auth_ctx = parts.extensions.get::<OrganizationContext>().cloned();
+        let header_org_id = OrgId::try_from_headers(&parts.headers).ok();
+
+        if let (Some(ctx), Some(hdr_id)) = (&auth_ctx, &header_org_id) {
+            if &ctx.org_id != hdr_id {
+                let req_id = ctx.request_id.as_uuid().to_string();
+                tracing::warn!(
+                    request_id = %req_id,
+                    claim_org = %ctx.org_id,
+                    header_org = %hdr_id,
+                    "org isolation: principal claim and X-Org-Id header disagree"
+                );
+                return Err(HandlerError(ApiError::forbidden(
+                    "cross-tenant request rejected",
+                )));
+            }
+        }
+
+        if let Some(ctx) = auth_ctx {
+            parts.extensions.insert(OrgContextSource::PrincipalClaim);
+            return Ok(OrgContextExtractor(ctx));
+        }
+
+        if let Some(org_id) = header_org_id {
+            let org_path: Vec<OrgId> = parts
+                .headers
+                .get("x-org-path")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|s| s.parse::<OrgPath>().ok())
+                .map(|p| p.into_inner())
+                .unwrap_or_else(|| vec![org_id]);
+
+            let request_id = extract_request_id_from_parts(parts);
+
+            use api_bones::audit::Principal;
+            let ctx =
+                OrganizationContext::new(org_id, Principal::system("unauthenticated"), request_id)
+                    .with_org_path(org_path);
+
+            parts.extensions.insert(ctx.clone());
+            parts.extensions.insert(OrgContextSource::Header);
+            return Ok(OrgContextExtractor(ctx));
+        }
+
+        Err(HandlerError(ApiError::unauthorized("missing org context")))
+    }
+}
+
+fn extract_request_id_from_parts(parts: &Parts) -> RequestId {
+    parts
+        .extensions
+        .get::<tower_http::request_id::RequestId>()
+        .and_then(|id| id.header_value().to_str().ok())
+        .and_then(|s| s.parse::<uuid::Uuid>().ok())
+        .map(RequestId::from_uuid)
+        .unwrap_or_default()
+}
+
+// ── OrgIsolationLayer ────────────────────────────────────────────────────────
+
+/// Tower layer that short-circuits with `401 Unauthorized` when an
+/// [`OrganizationContext`] extension is absent from the request.
+///
+/// Place this layer *after* auth middleware (or after a service that runs
+/// [`OrgContextExtractor`] logic) so the extension is guaranteed to be present.
+#[derive(Clone, Default)]
+pub struct OrgIsolationLayer;
+
+impl<S> Layer<S> for OrgIsolationLayer {
+    type Service = OrgIsolationService<S>;
+
+    fn layer(&self, inner: S) -> Self::Service {
+        OrgIsolationService { inner }
+    }
+}
+
+/// Service produced by [`OrgIsolationLayer`].
+#[derive(Clone)]
+pub struct OrgIsolationService<S> {
+    inner: S,
+}
+
+impl<S, ReqBody> Service<axum::http::Request<ReqBody>> for OrgIsolationService<S>
+where
+    S: Service<axum::http::Request<ReqBody>, Response = Response> + Send + Clone + 'static,
+    S::Future: Send + 'static,
+    ReqBody: Send + 'static,
+{
+    type Response = Response;
+    type Error = S::Error;
+    type Future = Pin<Box<dyn Future<Output = Result<Response, S::Error>> + Send>>;
+
+    fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), S::Error>> {
+        self.inner.poll_ready(cx)
+    }
+
+    fn call(&mut self, req: axum::http::Request<ReqBody>) -> Self::Future {
+        if req.extensions().get::<OrganizationContext>().is_none() {
+            let response =
+                HandlerError(ApiError::unauthorized("missing org context")).into_response();
+            return Box::pin(async move { Ok(response) });
+        }
+        let fut = self.inner.call(req);
+        Box::pin(fut)
+    }
+}

--- a/src/org_policy.rs
+++ b/src/org_policy.rs
@@ -1,0 +1,56 @@
+//! Org-scoped access policy trait and default ancestry implementation.
+
+use api_bones::error::{ApiError, ErrorCode};
+use api_bones::org_context::OrganizationContext;
+use api_bones::org_id::OrgId;
+
+// ── OrgPolicy ────────────────────────────────────────────────────────────────
+
+/// Policy that determines whether a caller may access resources belonging to
+/// a target org.
+pub trait OrgPolicy: Send + Sync {
+    /// Return `Ok(())` if `caller` is allowed to access `target`, or an
+    /// [`ApiError`] describing the denial.
+    fn allows(&self, caller: &OrganizationContext, target: &OrgId) -> Result<(), ApiError>;
+
+    /// Convenience wrapper — returns a `403 Forbidden` with
+    /// `detail: "cross-org access denied"` on rejection, preserving
+    /// `caller.request_id` as the RFC 9457 `instance`.
+    fn check_target(&self, caller: &OrganizationContext, target: &OrgId) -> Result<(), ApiError> {
+        self.allows(caller, target).map_err(|_| {
+            ApiError::new(ErrorCode::Forbidden, "cross-org access denied")
+                .with_request_id(caller.request_id.as_uuid())
+        })
+    }
+}
+
+// ── AncestryOrgPolicy ────────────────────────────────────────────────────────
+
+/// Default [`OrgPolicy`] implementation.
+///
+/// Allows access when `target` is `caller.org_id` (self) or appears in the
+/// descendant suffix of `caller.org_path` (i.e. any `OrgId` in `org_path`
+/// that comes after `caller.org_id`).
+///
+/// All other cases (sibling, ancestor, unrelated) are denied.
+pub struct AncestryOrgPolicy;
+
+impl OrgPolicy for AncestryOrgPolicy {
+    fn allows(&self, caller: &OrganizationContext, target: &OrgId) -> Result<(), ApiError> {
+        if &caller.org_id == target {
+            return Ok(());
+        }
+        // Allow access to a descendant node when org_path is extended beyond
+        // org_id (i.e. the auth layer granted subtree scope).
+        let self_pos = caller.org_path.iter().position(|id| id == &caller.org_id);
+        if let Some(pos) = self_pos {
+            if caller.org_path[pos + 1..].contains(target) {
+                return Ok(());
+            }
+        }
+        Err(ApiError::new(
+            ErrorCode::Forbidden,
+            "cross-org access denied",
+        ))
+    }
+}

--- a/tests/org_isolation.rs
+++ b/tests/org_isolation.rs
@@ -1,0 +1,163 @@
+use axum::Router;
+use axum::body::Body;
+use axum::extract::FromRequestParts;
+use axum::http::{Request, StatusCode};
+use axum::response::IntoResponse;
+use axum::routing::get;
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+use api_bones::audit::Principal;
+use api_bones::org_context::OrganizationContext;
+use api_bones::org_id::OrgId;
+use api_bones::request_id::RequestId;
+
+use socle::org_isolation::{OrgContextExtractor, OrgContextSource, OrgIsolationLayer};
+
+fn make_ctx(org_id: OrgId) -> OrganizationContext {
+    OrganizationContext::new(org_id, Principal::system("test"), RequestId::new())
+        .with_org_path(vec![org_id])
+}
+
+// ── OrgContextExtractor ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn extractor_claim_only_resolves() {
+    let org_id = OrgId::generate();
+    let mut req = Request::builder().uri("/").body(()).unwrap();
+    req.extensions_mut().insert(make_ctx(org_id));
+    let (mut parts, ()) = req.into_parts();
+
+    let result = OrgContextExtractor::from_request_parts(&mut parts, &()).await;
+    assert!(result.is_ok());
+    let OrgContextExtractor(ctx) = result.unwrap();
+    assert_eq!(ctx.org_id, org_id);
+    assert_eq!(
+        parts.extensions.get::<OrgContextSource>(),
+        Some(&OrgContextSource::PrincipalClaim)
+    );
+}
+
+#[tokio::test]
+async fn extractor_header_only_resolves() {
+    let org_id = OrgId::generate();
+    let req = Request::builder()
+        .uri("/")
+        .header("x-org-id", org_id.to_string())
+        .body(())
+        .unwrap();
+    let (mut parts, ()) = req.into_parts();
+
+    let result = OrgContextExtractor::from_request_parts(&mut parts, &()).await;
+    assert!(result.is_ok());
+    let OrgContextExtractor(ctx) = result.unwrap();
+    assert_eq!(ctx.org_id, org_id);
+    assert_eq!(
+        parts.extensions.get::<OrgContextSource>(),
+        Some(&OrgContextSource::Header)
+    );
+}
+
+#[tokio::test]
+async fn extractor_conflicting_claim_and_header_rejects_403() {
+    let claim_org = OrgId::generate();
+    let header_org = OrgId::generate();
+    assert_ne!(claim_org, header_org);
+
+    let mut req = Request::builder()
+        .uri("/")
+        .header("x-org-id", header_org.to_string())
+        .body(())
+        .unwrap();
+    req.extensions_mut().insert(make_ctx(claim_org));
+    let (mut parts, ()) = req.into_parts();
+
+    let result = OrgContextExtractor::from_request_parts(&mut parts, &()).await;
+    assert!(result.is_err());
+    let err = result.unwrap_err();
+    let resp = err.into_response();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn extractor_missing_both_rejects_401() {
+    let req = Request::builder().uri("/").body(()).unwrap();
+    let (mut parts, ()) = req.into_parts();
+
+    let result = OrgContextExtractor::from_request_parts(&mut parts, &()).await;
+    assert!(result.is_err());
+    let resp = result.unwrap_err().into_response();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
+async fn extractor_inserts_extension_on_success() {
+    let org_id = OrgId::generate();
+    let req = Request::builder()
+        .uri("/")
+        .header("x-org-id", org_id.to_string())
+        .body(())
+        .unwrap();
+    let (mut parts, ()) = req.into_parts();
+
+    OrgContextExtractor::from_request_parts(&mut parts, &())
+        .await
+        .unwrap();
+
+    assert!(parts.extensions.get::<OrganizationContext>().is_some());
+}
+
+// ── OrgIsolationLayer ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn isolation_layer_passes_with_extension() {
+    let org_id = OrgId::generate();
+    let app = Router::new()
+        .route("/", get(|| async { "ok" }))
+        .layer(OrgIsolationLayer);
+
+    let mut req = Request::builder().uri("/").body(Body::empty()).unwrap();
+    req.extensions_mut().insert(make_ctx(org_id));
+
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn isolation_layer_short_circuits_401_without_extension() {
+    let app = Router::new()
+        .route("/", get(|| async { "ok" }))
+        .layer(OrgIsolationLayer);
+
+    let req = Request::builder().uri("/").body(Body::empty()).unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+// ── Integration: OrgContextExtractor middleware + OrgIsolationLayer ───────────
+
+#[tokio::test]
+async fn integration_extractor_middleware_with_isolation_layer() {
+    use axum::middleware;
+
+    async fn inject_org_ctx(
+        mut req: Request<Body>,
+        next: middleware::Next,
+    ) -> axum::response::Response {
+        let org_id = OrgId::generate();
+        req.extensions_mut().insert(make_ctx(org_id));
+        next.run(req).await
+    }
+
+    let app = Router::new()
+        .route("/", get(|| async { "ok" }))
+        .layer(OrgIsolationLayer)
+        .layer(middleware::from_fn(inject_org_ctx));
+
+    let req = Request::builder().uri("/").body(Body::empty()).unwrap();
+    let resp = app.oneshot(req).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let bytes = resp.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(&bytes[..], b"ok");
+}

--- a/tests/org_policy.rs
+++ b/tests/org_policy.rs
@@ -1,0 +1,76 @@
+use api_bones::audit::Principal;
+use api_bones::org_context::OrganizationContext;
+use api_bones::org_id::OrgId;
+use api_bones::request_id::RequestId;
+
+use socle::org_policy::{AncestryOrgPolicy, OrgPolicy};
+
+fn ctx_with_path(org_id: OrgId, org_path: Vec<OrgId>) -> OrganizationContext {
+    OrganizationContext::new(org_id, Principal::system("test"), RequestId::new())
+        .with_org_path(org_path)
+}
+
+#[test]
+fn ancestry_allows_self() {
+    let org_id = OrgId::generate();
+    let ctx = ctx_with_path(org_id, vec![org_id]);
+    assert!(AncestryOrgPolicy.allows(&ctx, &org_id).is_ok());
+}
+
+#[test]
+fn ancestry_allows_descendant() {
+    let root = OrgId::generate();
+    let caller_org = OrgId::generate();
+    let child_org = OrgId::generate();
+    // org_path extends beyond caller_org to represent a subtree grant.
+    let ctx = ctx_with_path(caller_org, vec![root, caller_org, child_org]);
+    assert!(AncestryOrgPolicy.allows(&ctx, &child_org).is_ok());
+}
+
+#[test]
+fn ancestry_rejects_sibling() {
+    let root = OrgId::generate();
+    let caller_org = OrgId::generate();
+    let sibling_org = OrgId::generate();
+    let ctx = ctx_with_path(caller_org, vec![root, caller_org]);
+    assert!(AncestryOrgPolicy.allows(&ctx, &sibling_org).is_err());
+}
+
+#[test]
+fn ancestry_rejects_ancestor() {
+    let root = OrgId::generate();
+    let parent = OrgId::generate();
+    let caller_org = OrgId::generate();
+    let ctx = ctx_with_path(caller_org, vec![root, parent, caller_org]);
+    // parent is an ancestor of caller — should be denied
+    assert!(AncestryOrgPolicy.allows(&ctx, &parent).is_err());
+    assert!(AncestryOrgPolicy.allows(&ctx, &root).is_err());
+}
+
+#[test]
+fn ancestry_rejects_unrelated_org() {
+    let caller_org = OrgId::generate();
+    let unrelated = OrgId::generate();
+    let ctx = ctx_with_path(caller_org, vec![caller_org]);
+    assert!(AncestryOrgPolicy.allows(&ctx, &unrelated).is_err());
+}
+
+#[test]
+fn check_target_returns_forbidden_with_detail() {
+    let caller_org = OrgId::generate();
+    let other_org = OrgId::generate();
+    let ctx = ctx_with_path(caller_org, vec![caller_org]);
+    let err = AncestryOrgPolicy
+        .check_target(&ctx, &other_org)
+        .unwrap_err();
+    assert_eq!(err.status_code(), 403);
+    assert_eq!(err.detail, "cross-org access denied");
+    assert!(err.request_id.is_some());
+}
+
+#[test]
+fn check_target_ok_on_self() {
+    let org_id = OrgId::generate();
+    let ctx = ctx_with_path(org_id, vec![org_id]);
+    assert!(AncestryOrgPolicy.check_target(&ctx, &org_id).is_ok());
+}


### PR DESCRIPTION
## Summary

- `OrgContextExtractor`: Axum `FromRequestParts` extractor resolving `OrganizationContext` from a principal extension (auth layer) or `X-Org-Id`/`X-Org-Path` headers, with cross-tenant conflict detection (403 + tracing warn).
- `OrgIsolationLayer`: Tower middleware short-circuiting with 401 when `OrganizationContext` is absent from request extensions.
- `OrgPolicy` trait + `AncestryOrgPolicy`: org-scoped access control, allowing self and subtree-granted descendants.


Closes #38

## Test plan

- [x] `extractor_claim_only_resolves` — principal extension path
- [x] `extractor_header_only_resolves` — X-Org-Id header path
- [x] `extractor_conflicting_claim_and_header_rejects_403` — cross-tenant detection
- [x] `extractor_missing_both_rejects_401` — no source available
- [x] `extractor_inserts_extension_on_success` — extension written to parts
- [x] `isolation_layer_passes_with_extension` — happy path
- [x] `isolation_layer_short_circuits_401_without_extension` — enforcement
- [x] `integration_extractor_middleware_with_isolation_layer` — end-to-end smoke test
- [x] `ancestry_allows_self`, `ancestry_allows_descendant`, `ancestry_rejects_sibling/ancestor/unrelated`
- [x] `check_target_returns_forbidden_with_detail` — request_id preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)