### PR TITLE
feat(handler): add CreatedAtResponse + created_at helper with Location header

### DIFF
--- a/src/handler_error.rs
+++ b/src/handler_error.rs
@@ -85,6 +85,16 @@ pub type CreatedResponse<T> = Result<
     HandlerError,
 >;
 
+/// Return type for handlers that create a resource and return it with a 201 status and Location header.
+pub type CreatedAtResponse<T> = Result<
+    (
+        axum::http::StatusCode,
+        axum::http::HeaderMap,
+        axum::Json<api_bones::ApiResponse<T>>,
+    ),
+    HandlerError,
+>;
+
 /// Return type for read/update handlers that carry an ETag response header.
 pub type EtaggedHandlerResponse<T> = Result<
     (
@@ -99,6 +109,20 @@ pub type EtaggedHandlerResponse<T> = Result<
 pub fn created<T>(value: T) -> CreatedResponse<T> {
     Ok((
         axum::http::StatusCode::CREATED,
+        axum::Json(api_bones::ApiResponse::builder(value).build()),
+    ))
+}
+
+/// Build the success response for a [`CreatedAtResponse`] handler (201 Created + Location header).
+pub fn created_at<T>(location: &str, value: T) -> CreatedAtResponse<T> {
+    let mut headers = axum::http::HeaderMap::new();
+    headers.insert(
+        axum::http::header::LOCATION,
+        location.parse().expect("valid Location URI"),
+    );
+    Ok((
+        axum::http::StatusCode::CREATED,
+        headers,
         axum::Json(api_bones::ApiResponse::builder(value).build()),
     ))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,9 +60,9 @@ pub use config::{BootstrapConfig, CorsConfig, LogFormat, RateLimitConfig, RateLi
 pub use error::{Error, Result};
 pub use etag::{ETag, IfMatch, IfNoneMatch, check_if_match, etag_from_updated_at};
 pub use handler_error::{
-    ApiError, CreatedResponse, ErrorCode, EtaggedHandlerResponse, HandlerError,
-    HandlerListResponse, HandlerResponse, ProblemJson, ValidationError, created, etagged, listed,
-    listed_page, ok,
+    ApiError, CreatedAtResponse, CreatedResponse, ErrorCode, EtaggedHandlerResponse, HandlerError,
+    HandlerListResponse, HandlerResponse, ProblemJson, ValidationError, created, created_at,
+    etagged, listed, listed_page, ok,
 };
 pub use org_isolation::{
     OrgContextExtractor, OrgContextSource, OrgIsolationLayer, OrgIsolationService,


### PR DESCRIPTION
## Summary

- Adds `CreatedAtResponse<T>` type: `Result<(StatusCode, HeaderMap, Json<ApiResponse<T>>), HandlerError>`
- Adds `created_at(location, value)` helper that emits 201 Created with a `Location` header, fulfilling ADR-0016 §"Create response contract"
- Exports both from the crate's public surface

Closes #41

## Test plan

- [x] `cargo test` passes (all unit + doc tests green)
- [x] Follows the same structural pattern as `etagged` (status + headers + body tuple)
- [ ] First caller: `quorate` `create_deadline` handler (brefwiz/quorate#79) will migrate to `created_at` once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)