### PR TITLE
chore(release): v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [2.5.0] — 2026-04-25
 
 ### Added
 
@@ -8,6 +8,8 @@
 - `OrgIsolationLayer` — Tower middleware that short-circuits with `401 Unauthorized` when `OrganizationContext` is absent from request extensions.
 - `OrgContextSource` — enum recording which mechanism resolved the org context (`PrincipalClaim` or `Header`).
 - `OrgPolicy` trait + `AncestryOrgPolicy` — policy trait for org-scoped access control, with a default ancestry-based implementation.
+- `CreatedAtResponse<T>` + `created_at(location, value)` helper — returns `201 Created` with a `Location` header alongside the JSON body, mirroring `ok` / `created` / `listed` ergonomics.
+- `AuditLayer` — Tower middleware that captures request/response audit events to a pluggable `AuditSink`, with built-in sinks for tracing and in-memory collection.
 
 ## [2.4.0] — 2026-04-24
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3218,7 +3218,7 @@ dependencies = [
 
 [[package]]
 name = "socle"
-version = "2.4.0"
+version = "2.5.0"
 dependencies = [
  "api-bones",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "socle"
-version = "2.4.0"
+version = "2.5.0"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 description = "Opinionated axum service bootstrap: telemetry, database, rate limiting, and shutdown in one builder"


### PR DESCRIPTION
## Summary
- Bump 2.4.0 → 2.5.0
- New since v2.4.0: org isolation extractor + policy layer, `created_at` / `CreatedAtResponse` helper, audit Tower layer with pluggable sinks

## Notes
- Inline `/// # Examples` doc blocks not yet added for `OrgIsolationLayer` / `AuditLayer` — module-level integration tests exist but rustdoc examples could be added in a follow-up.

## Test plan
- [ ] CI green
- [ ] `cargo publish --dry-run` clean