### PR TITLE
feat: add created_under helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## [2.6.0] — 2026-04-25
+
+### Added
+
+- `created_under(prefix, value)` — composes a 201 Created Location header from
+  a route prefix + `value.id()` (requires `api_bones::HasId`). Decouples DTOs
+  from HTTP route paths while keeping the call site to one line.
+- Bump `api-bones` `4.0.1` → `4.5.0` (adds `HasId`).
+
 ## [2.5.1] — 2026-04-25
 
 ### Security

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-bones"
-version = "4.0.1"
+version = "4.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e167c9c1eac92725b26c0fc958a01696981d83128ebc4f860e3071fe1d006c0"
+checksum = "50772f5282534857e3da570b2c3148a8895827a029837d962f9fe68b8b166c2c"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3156,7 +3156,7 @@ dependencies = [
 
 [[package]]
 name = "socle"
-version = "2.5.1"
+version = "2.6.0"
 dependencies = [
  "api-bones",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "socle"
-version = "2.5.1"
+version = "2.6.0"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 description = "Opinionated axum service bootstrap: telemetry, database, rate limiting, and shutdown in one builder"
@@ -58,7 +58,7 @@ serde_json = "1"
 figment = { version = "0.10", features = ["env", "toml"] }
 chrono = { version = "0.4", features = ["serde"] }
 
-api-bones = { version = "4.0.1", features = ["axum", "uuid"] }
+api-bones = { version = "=4.5.0", features = ["axum", "uuid"] }
 
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "postgres", "migrate"], optional = true }
 

--- a/src/handler_error.rs
+++ b/src/handler_error.rs
@@ -127,6 +127,19 @@ pub fn created_at<T>(location: &str, value: T) -> CreatedAtResponse<T> {
     ))
 }
 
+/// Build a 201 Created response whose Location header is composed from
+/// `prefix` + `/` + `value.id()`. The prefix is typically the route path
+/// (e.g. `"/v1/items"`); the id comes from the value's `HasId` impl.
+///
+/// Use this when the route is the source of truth for the URL pattern and
+/// the DTO only commits to "I have an id." Trailing slashes on `prefix`
+/// are trimmed so `"/v1/items/"` and `"/v1/items"` produce the same
+/// Location.
+pub fn created_under<T: api_bones::HasId>(prefix: &str, value: T) -> CreatedAtResponse<T> {
+    let location = format!("{}/{}", prefix.trim_end_matches('/'), value.id());
+    created_at(&location, value)
+}
+
 /// Build the success response for a [`HandlerResponse`] handler (200 OK).
 pub fn ok<T>(value: T) -> HandlerResponse<T> {
     Ok((
@@ -305,5 +318,44 @@ mod tests {
         let body = listed_page::<u32, u64>(items, &params).unwrap();
         let json = serde_json::to_value(body.0).unwrap();
         assert_eq!(json["data"]["items"].as_array().unwrap().len(), 20);
+    }
+
+    #[test]
+    fn created_under_composes_location() {
+        struct R {
+            id: u64,
+        }
+        impl api_bones::HasId for R {
+            type Id = u64;
+            fn id(&self) -> &u64 {
+                &self.id
+            }
+        }
+        let resp = created_under("/v1/widgets", R { id: 7 }).unwrap();
+        let (status, headers, _body) = resp;
+        assert_eq!(status, axum::http::StatusCode::CREATED);
+        assert_eq!(
+            headers.get(axum::http::header::LOCATION).unwrap(),
+            "/v1/widgets/7"
+        );
+    }
+
+    #[test]
+    fn created_under_trims_trailing_slash() {
+        struct R {
+            id: String,
+        }
+        impl api_bones::HasId for R {
+            type Id = String;
+            fn id(&self) -> &String {
+                &self.id
+            }
+        }
+        let resp = created_under("/v1/things/", R { id: "abc".into() }).unwrap();
+        let (_, headers, _) = resp;
+        assert_eq!(
+            headers.get(axum::http::header::LOCATION).unwrap(),
+            "/v1/things/abc"
+        );
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,7 +67,7 @@ pub use etag::{ETag, IfMatch, IfNoneMatch, check_if_match, etag_from_updated_at}
 pub use handler_error::{
     ApiError, CreatedAtResponse, CreatedResponse, ErrorCode, EtaggedHandlerResponse, HandlerError,
     HandlerListResponse, HandlerResponse, ProblemJson, ValidationError, created, created_at,
-    etagged, listed, listed_page, ok,
+    created_under, etagged, listed, listed_page, ok,
 };
 
 #[cfg(feature = "test-util")]


### PR DESCRIPTION
## Summary

- `created_under(prefix, value)` — composes a 201 Created Location header from
  a route prefix + `value.id()` (requires `api_bones::HasId`). Decouples DTOs
  from HTTP route paths while keeping the call site to one line.
- Bump `api-bones` `4.0.1` → `4.5.0` (adds `HasId`).

## Test plan

- [x] `created_under_composes_location` — verifies status 201 and Location header
- [x] `created_under_trims_trailing_slash` — verifies trailing slash on prefix is normalized

After merge: tag v2.6.0 and publish per existing release process.