### PR TITLE
chore(release): bump socle 3.0.1 → 3.1.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "socle"
-version = "3.0.1"
+version = "3.1.0"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 description = "Opinionated axum service bootstrap: telemetry, database, rate limiting, and shutdown in one builder"


### PR DESCRIPTION
## Summary

Releases `socle 3.1.0` to ship the `api-bones =4.6.0` bump (merged in #51).

## Why minor (not patch)

`socle` re-exports `api-bones` types through its public API surface (`pub use api_bones::*` and trait/type aliases). When `api-bones` adds new types or methods at a minor version, those become observable changes for `socle` consumers — minor by SemVer.

## Coordination

After this PR merges and `socle 3.1.0` is published, `service-kit` will bump its `socle` dep to `3.1.0` (and its own version) to release a unified `service-kit 3.1.0`. Downstream consumers (mempalace-rs, quorate, quorumauth, itinerwiz, etc.) will then resolve cleanly to the new socle/service-kit/api-bones triple.

## Test plan

- [ ] `cargo build --workspace` passes
- [ ] `cargo test --workspace` passes
- [ ] `make pre-commit` passes
- [ ] After merge: `cargo publish` to brefwiz registry succeeds
