### PR TITLE
fix(deps): regenerate Cargo.lock to match api-bones =4.6.0 pin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-bones"
-version = "4.5.0"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50772f5282534857e3da570b2c3148a8895827a029837d962f9fe68b8b166c2c"
+checksum = "acfa0c470828d3388d29d0b26e65e6900736802c67cf1ada982d8eaff98f5f77"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3156,7 +3156,7 @@ dependencies = [
 
 [[package]]
 name = "socle"
-version = "3.0.1"
+version = "3.1.0"
 dependencies = [
  "api-bones",
  "async-nats",


### PR DESCRIPTION
## Summary

Regenerates `Cargo.lock` to match `Cargo.toml`'s `api-bones = "=4.6.0"` pin (already on main from #51). PR #51 bumped Cargo.toml without regenerating Cargo.lock, so `cargo publish` refused to run on a dirty working tree.

## Why now

The v3.1.0 Release run failed on `cargo publish`:

```
Updating api-bones v4.5.0 -> v4.6.0
error: 1 files in the working directory contain changes that were not yet committed into git:
Cargo.lock
to proceed despite this and include the uncommitted changes, pass the `--allow-dirty` flag
```

That's blocking the entire api-bones 4.6.0 propagation campaign — every downstream wave (service-kit, consumers) waits on `socle 3.1.0` being on crates.io.

## Plan

1. Merge this PR.
2. Force-update the `v3.1.0` tag to point at the post-merge commit (the existing tag points at a pre-Cargo.lock-fix commit and would publish-fail again).
3. Release run re-fires on the new tag → `cargo publish` succeeds → `socle 3.1.0` lands on crates.io.

## Test plan

- [ ] `cargo check` passes against the new Cargo.lock locally
- [ ] CI passes
- [ ] After merge + tag move: Release run reaches the `Waiting for socle 3.1.0 to appear in crates.io index` step
