### PR TITLE
chore(adr-0021): wire ci-changelog Makefile target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ coverage/
 *.swo
 .idea/
 .vscode/
+.ci-workflows

--- a/Makefile
+++ b/Makefile
@@ -83,4 +83,10 @@ pre-commit: ci-format ci-lint ci-test ci-changelog ## Run all pre-commit checks 
 
 .PHONY: ci-changelog
 ci-changelog: ## CI: verify CHANGELOG.md has entry for current package version (ADR-0021)
-	@bash <(curl -fsSL https://raw.githubusercontent.com/brefwiz/shared-ci-workflows/main/scripts/check-release-changelog.sh)
+	@if [ -x .ci-workflows/ci-scripts/check-release-changelog.sh ]; then \
+		bash .ci-workflows/ci-scripts/check-release-changelog.sh; \
+	elif command -v check-release-changelog.sh >/dev/null 2>&1; then \
+		check-release-changelog.sh; \
+	else \
+		echo "ci-changelog: check-release-changelog.sh not found; skipping (run via CI for the full check)"; \
+	fi


### PR DESCRIPTION
## Summary

CI fix — the clippy action now calls `make ci-changelog` (per ci-workflows#80) instead of running the shared script directly. This repo's recipe was missing or broken: curl from renamed shared-ci-workflows host.

## What changed

Adopt the canonical recipe from `mempalace-rs`/`repo-template` that delegates to `.ci-workflows/ci-scripts/check-release-changelog.sh` when the action's checkout is present, falls back to `check-release-changelog.sh` on PATH, and gracefully no-ops for offline local invocations.

## Verified locally

- `make -n ci-changelog` resolves cleanly
- `bash ~/git/ci-workflows/ci-scripts/check-adr-0021.sh --strict-pre-commit` passes
