### PR TITLE
chore(deps): bump api-bones 4.6.0 → 4.7.0, release socle 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.2.0] — 2026-04-29
+
+### Changed
+
+- **Bump `api-bones` to `=4.7.0`** (from `=4.6.0`). Re-exported types from `api-bones` are observable through `socle`'s public API, so this is a minor bump for `socle` consumers.
+
 ## [3.1.0] — 2026-04-27
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-bones"
-version = "4.6.0"
+version = "4.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acfa0c470828d3388d29d0b26e65e6900736802c67cf1ada982d8eaff98f5f77"
+checksum = "97e3b1d5db792632182af2d1767c0f5d2d7f7309a03ca81678b8ef296eb07863"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -3156,7 +3156,7 @@ dependencies = [
 
 [[package]]
 name = "socle"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "api-bones",
  "async-nats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "socle"
-version = "3.1.0"
+version = "3.2.0"
 edition = "2024"
 authors = ["Gregoire Salingue"]
 description = "Opinionated axum service bootstrap: telemetry, database, rate limiting, and shutdown in one builder"
@@ -66,7 +66,7 @@ serde_json = "1"
 figment = { version = "0.10", features = ["env", "toml"] }
 chrono = { version = "0.4", features = ["serde"] }
 
-api-bones = { version = "=4.6.0", features = ["axum", "uuid"] }
+api-bones = { version = "=4.7.0", features = ["axum", "uuid"] }
 
 sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio-rustls", "postgres", "migrate"], optional = true }
 


### PR DESCRIPTION
## Summary
- Bump `api-bones` from `=4.6.0` to `=4.7.0`
- Release socle `3.2.0`

Part of api-bones 4.7.0 propagation campaign.