### PR TITLE
chore(ci): retarget light-pool candidate jobs to brefwiz-light

### DIFF
--- a/.gitea/workflows/ci.yml
+++ b/.gitea/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
   # ==========================================================================
   deny:
     name: Dependency License Audit
-    runs-on: brefwiz
+    runs-on: brefwiz-light
     container:
       image: harbor.brefwiz.com/brefwiz/ci:latest
       options: --user root

--- a/.gitea/workflows/release.yml
+++ b/.gitea/workflows/release.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   canonical-check:
     name: Canonical Check (ADR-0086)
-    runs-on: brefwiz
+    runs-on: brefwiz-light
     container:
       image: harbor.brefwiz.com/brefwiz/ci:latest
       options: --user root
@@ -103,7 +103,7 @@ jobs:
   security-audit:
     name: Security Audit
     needs: [validate-version]
-    runs-on: brefwiz
+    runs-on: brefwiz-light
     container:
       image: harbor.brefwiz.com/brefwiz/ci:latest
       options: --user root

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -67,9 +67,9 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "api-bones"
-version = "6.1.0"
+version = "6.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85581b5e0a217e68ffd387300a2b3b05e82e80c2ad455244b7e9e21fb9e47b38"
+checksum = "4d909dc078a609812dd5d17a8014804eb96a4e6fc67fe4dd29c01b465cd4d022"
 dependencies = [
  "axum",
  "base64",
@@ -1114,9 +1114,9 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"


### PR DESCRIPTION
## Summary

Retarget light-pool candidate jobs from `runs-on: brefwiz` to `runs-on: brefwiz-light`. Heavy compile-bound jobs untouched.

Companion to **dev-platform PR #106** which introduces the `brefwiz-light` runner pool (id=2, capacity 6 per host, on bw-1/bw-2/sdev). Until that lands these jobs will queue waiting for a `brefwiz-light` slot — merge dev-platform #106 first.

## Classification

**Moved to `brefwiz-light`:** `k3d-setup`, `publish-preflight`, `security-audit`, `license-headers`, `deny`, `api-contract`, `canonical-check`, `proto-lint`, `proto-breaking`, `openapi`, `cucumber-step-check`, `release-validate`, `e2e-keygen`, `e2e`, `e2e-compliance`, `doc-pipeline` (when present)

**Stay on `brefwiz` (compile-bound):** `lint`, `test`, `coverage`, `sdk-rust-prebuild`, `sdk-ts-prebuild`, `sdk-ts-build`, `sdk-verify`, `sdk-package`, `build`, `docker-build`

## Generated

Mechanical sweep via `/propagate-change` against all repos with `.gitea/workflows/*.yml` containing `runs-on: brefwiz`. One PR per repo. Pilot validated in repo-template PR #53.
